### PR TITLE
update td-agent installation docs for Ubuntu 12.04

### DIFF
--- a/docs/install-by-deb.txt
+++ b/docs/install-by-deb.txt
@@ -8,7 +8,14 @@ Fluentd is written in Ruby for the flexibility, but the installation and the ope
 
 ## Step1: Add the Apt Repository
 
-Currently, only "Ubuntu 10.04 LTS / Lucid" and "Debian Lenny" are supported.
+Currently, "Ubuntu 12.04 LTS / Precise", "Ubuntu 10.04 LTS / Lucid" and "Debian Lenny" are supported.
+
+#### Ubuntu Precise
+
+Please add the Treasure Data apt repository to your sources list. This command will set it up for you:
+
+    :::term
+    $ sudo apt-add-repository 'deb http://packages.treasure-data.com/debian/ precise contrib'
 
 #### Ubuntu Lucid
 


### PR DESCRIPTION
td-agent can be installed on Ubuntu 12.04 (Precise).

Reference:
http://help.treasure-data.com/kb/installing-td-agent-daemon/installing-td-agent-for-debian-and-ubuntu
