### PR TITLE
fix buffer configurations

### DIFF
--- a/docs/out_webhdfs.txt
+++ b/docs/out_webhdfs.txt
@@ -61,13 +61,13 @@ The path on HDFS. Please include ${hostname} in your path to avoid writing into 
 For advanced usage, you can tune Fluentd's internal buffering mechanism with these parameters.
 
 ### buffer_type
-The buffer type is `file` by default ([buf_file](buf_file)). The `memory` ([buf_memory](buf_memory)) buffer type can be chosen as well. The `path` parameter is used as `buffer_path` in this plugin.
+The buffer type is `memory` by default ([buf_memory](buf_memory)). The `file` ([buf_file](buf_file)) buffer type can be chosen as well. The `buffer_path` parameter MUST be specified with `buffer_type file`.
 
 ### buffer_queue_limit, buffer_chunk_limit
-The length of the chunk queue and the size of each chunk, respectively. Please see the [Buffer Plugin Overview](buffer-plugin-overview) article for the basic buffer structure. The default values are 256 and 8m, respectively. The suffixes “k” (KB), “m” (MB), and “g” (GB) can be used for buffer_chunk_limit.
+The length of the chunk queue and the size of each chunk, respectively. Please see the [Buffer Plugin Overview](buffer-plugin-overview) article for the basic buffer structure. The default values are 64 and 256m, respectively. The suffixes “k” (KB), “m” (MB), and “g” (GB) can be used for buffer_chunk_limit.
 
 ### flush_interval
-The interval between data flushes. The default is 1s. The suffixes “s” (seconds), “m” (minutes), and “h” (hours) can be used.
+The interval between force data flushes. The default is nil (not refered). The suffixes “s” (seconds), “m” (minutes), and “h” (hours) can be used.
 
 ### retry_wait and retry_limit
 The interval between write retries, and the number of retries. The default values are 1.0 and 17, respectively. `retry_wait` doubles every retry (e.g. the last retry waits for 131072 sec, roughly 36 hours).


### PR DESCRIPTION
fix buffer configurations such as:
 \* specified in out_webhdfs.rb
   \* buffer_type memory
   \* buffer_path must be specified for `buffer_type file`
 \* TimeSlicedOutput default options
   \* flush_interval nil
   \* buffer_chunk_limit 256m
 \* buf_memory's default options:
   \* buffer_queue_limit 64

Are these descriptions copy&past-ed from out_exec_filter's documents?
(originally `flush_interval 1s`)
