### PR TITLE
Avoid garbled in "text" section.

### DIFF
--- a/docs/ja/in_forward.txt
+++ b/docs/ja/in_forward.txt
@@ -33,13 +33,13 @@ NOTE: 設定ファイルの基本的な構造や文法に関しては、<a href=
 このプラグインは内部プロトコルとして[MessagePack](http://msgpack.org/)を使用しています。 MessagePack はバイナリベースのシリアライズ/デシリアライズライブラリーです。`in_forward`はMessagePackデータストリームを次の構造で受け付けます。
 
     :::text
-    ストリーム:
-      メッセージ...
+    stream:
+      message...
 
-    メッセージ:
+    message:
       [tag, time, record]
-      または
+      or
       [tag, [[time,record], [time,record], ...]]
 
-    例:
+    example:
       ["myapp.access", [1308466941, {"a"=>1}], [1308466942, {"b"=>2}]]


### PR DESCRIPTION
Revert to English a few parts of "ja/in_forward.txt", because "text" section was garbled.
It seems that problem of except for the Translation.

---

Please refer following commit and image.

commit: 
https://github.com/fluent/fluentd-docs/blob/c784726bc027cb9725dd712ccd396d2b79175537/docs/ja/in_forward.txt#L35-L45

image: 
![screen shot 2014-01-04 at 8 09 38 am](https://f.cloud.github.com/assets/194222/1843370/9f7dccc4-74cf-11e3-9419-9a021ac24656.png)
