### PR TITLE
Add newline to enable 'INCLUDE' pragma

### DIFF
--- a/docs/out_copy.txt
+++ b/docs/out_copy.txt
@@ -61,3 +61,4 @@ When `deep_copy` is true, `out_copy` passes different record to each `store` plu
 Specifies the storage destinations. The format is the same as the &lt;match&gt; directive.
 
 INCLUDE: _log_level_params
+

--- a/docs/out_stdout.txt
+++ b/docs/out_stdout.txt
@@ -25,3 +25,4 @@ Output format. The following formats are supported:
 * hash (Ruby's hash)
 
 INCLUDE: _log_level_params
+


### PR DESCRIPTION
In out_copy.txt and out_stdout.txt, 'INCLUDE' pragma doesn't work because it needs two newline characters.

![include001](https://cloud.githubusercontent.com/assets/1905688/2917239/8e8fa0c6-d6c3-11e3-9743-1045d972d6f3.jpg)
