### PR TITLE
Newline characters may be necessary for text that substituted by 'INCLUDE' pragma

### DIFF
--- a/lib/article.rb
+++ b/lib/article.rb
@@ -53,7 +53,7 @@ class Article
 
   def includes(source)
     source.gsub(/INCLUDE: (.*?)\n\n/m) { |pattern|
-      includes(File.read("#{@prefix}/#{$1}.txt"))
+      includes(File.read("#{@prefix}/#{$1}.txt")) + "\n\n"
     }
   end
   


### PR DESCRIPTION
Suppose the following text file (docs/*.txt):

```
INCLUDE: _foo

INCLUDE: _bar


```

Now, after substitution:

```
included foo.included bar.
```

This causes the following result.

![include002](https://cloud.githubusercontent.com/assets/1905688/2917291/2aef6f82-d6c4-11e3-877d-45bc7190e4a2.jpg)

The expectation that I think of is:

```
included foo.

included bar.


```
