### PR TITLE
Fix typos for in_udp

### DIFF
--- a/docs/in_udp.txt
+++ b/docs/in_udp.txt
@@ -45,7 +45,7 @@ Specify body format by regular expression.
 If you execute following command:
 
     :::term
-    $ echo '123456:awesome' | netcat -u 0.0.0.0 5170
+    $ echo '123456:awesome' | netcat -u 0.0.0.0 5160
 
 then got parsed result like below:
 


### PR DESCRIPTION
Add required parameters (format and tag) to example in_udp config.  Also tell netcat to use UDP switch vs TCP, and use default port in the example.  Using 5170 tripped me up for a bit.

Thanks!
