### PR TITLE
adding sample in / out Secure Forward configs, together on one page

### DIFF
--- a/docs/in_secure_forward.txt
+++ b/docs/in_secure_forward.txt
@@ -90,6 +90,9 @@ You can use the username/password check and client check together:
       </client>
     </source>
 
+###Secure Sender-Receiver Setup
+Please refer to the **Secure Sender-Receiver Setup** [sample documentation](out_secure_forward#Secure-Sender-Receiver-Setup).
+
 ##Parameters
 
 ####type

--- a/docs/out_secure_forward.txt
+++ b/docs/out_secure_forward.txt
@@ -75,6 +75,215 @@ Use the `keepalive` parameter to specify keepalive timeouts. For example, the co
       </server>
     </match>
 
+
+###Secure Sender-Receiver Setup
+
+Example to send and receive several different kinds of logs (format is set to none for simplicity here).
+
+####Sender 
+
+
+    # td-agent secured client (sender)
+    
+    <source>
+        type tail
+        path /appbase/logs/apache/apache_access_log
+        pos_file /var/log/td-agent/tmp/apache.access.pos
+        tag apache.access
+        format none
+    </source>
+    
+    <source>
+        type tail
+        path /appbase/logs/apache/apache_error_log
+        pos_file /var/log/td-agent/tmp/apache.error.pos
+        tag apache.error
+        format none
+    </source>
+    
+    <source>
+        type tail
+        path /appbase/logs/webapp/elastic_search.log
+        pos_file /var/log/td-agent/tmp/elastic.search.pos
+        tag elastic.search
+        format none
+    </source>
+    
+    <source>
+        type tail
+        path /appbase/logs/webapp/elastic_search_poller.log
+        pos_file /var/log/td-agent/tmp/elastic.search.poller.pos
+        tag elastic.poller
+        format none
+    </source>
+    
+    <source>
+        type tail
+        path /appbase/logs/webapp/ldap.log
+        pos_file /var/log/td-agent/tmp/ldap.log.pos
+        tag ldap.log
+        format none
+    </source>
+    
+    
+    
+    #-- Application Logs
+    
+    <match apache.*>
+        type copy
+        <store>
+           type secure_forward
+           shared_key Supers3cr3t
+           allow_self_signed_certificate true
+           self_hostname frontend01.dev.company.net
+            <server>
+              host logserver01.prd.company.net
+              port 2514
+            </server>
+           <server>
+             host logserver02.prd.company.net
+             port 2514
+           </server>
+        </store>
+    </match>
+
+    <match elastic.*>
+        type copy
+        <store>
+           type secure_forward
+           shared_key Supers3cr3t
+           allow_self_signed_certificate true
+           self_hostname frontend01.dev.company.net
+            <server>
+              host logserver01.prd.company.net
+              port 2514
+            </server>
+           <server>
+             host logserver02.prd.company.net
+             port 2514
+           </server>
+        </store>
+    </match>
+    
+    <match ldap.*>
+        type copy
+        <store>
+           type secure_forward
+           shared_key Supers3cr3t
+           allow_self_signed_certificate true
+           self_hostname frontend01.dev.company.net
+            <server>
+              host logserver01.prd.company.net
+              port 2514
+            </server>
+           <server>
+             host logserver02.prd.company.net
+             port 2514
+           </server>
+        </store>
+    </match>
+    
+    #-- NOTE for troubleshooting any actions afer "type copy",
+    #-- and receive more output in td-agent.log, add:
+    #--       <store>
+    #--           type stdout
+    #--       </store>
+    
+    
+    #-- Fluent Internal Logs
+    
+    <match **>
+       type secure_forward
+       shared_key Supers3cr3t
+       self_hostname frontend01.dev.company.net
+       flush_interval 8s
+       <server>
+         host logserver01.prd.company.net
+         port 2514
+       </server>
+       <server>
+         host logserver02.prd.company.net
+         port 2514
+       </server>
+    </match>
+
+
+####Receiver
+
+    # td-agent secured receiver (server)
+    
+    <source>
+      type secure_forward
+      shared_key         Supers3cr3t
+      self_hostname      logserver01.prd.company.net
+      cert_auto_generate yes
+      port 2514
+    </source>
+    
+    
+    #-- Application Logs
+    
+    <match *.access>
+        type file
+        append true
+        path /appbase/logs/received/access
+        time_slice_format %Y%m%d
+        time_slice_wait 5m
+        time_format %Y%m%dT%H:%M:%S%z
+    </match>
+    
+    <match *.error>
+        type file
+        append true
+        path /appbase/logs/received/error
+        time_slice_format %Y%m%d
+        time_slice_wait 5m
+        time_format %Y%m%dT%H:%M:%S%z
+    </match>
+    
+    <match elastic.search>
+        type file
+        append true
+        path /appbase/logs/received/elastic_search
+        time_slice_format %Y%m%d
+        time_slice_wait 5m
+        time_format %Y%m%dT%H:%M:%S%z
+    </match>
+    
+    <match elastic.poller>
+        type file
+        append true
+        path /appbase/logs/received/elastic_search_poller
+        time_slice_format %Y%m%d
+        time_slice_wait 5m
+        time_format %Y%m%dT%H:%M:%S%z
+    </match>
+    
+    <match ldap.*>
+        type file
+        append true
+        path /appbase/logs/received/ldap
+        time_slice_format %Y%m%d
+        time_slice_wait 5m
+        time_format %Y%m%dT%H:%M:%S%z
+    </match>
+    
+    
+    #-- Fluent Internal Logs
+
+    <match fluent.info>
+        type file
+        append true
+        path /appbase/logs/received/fluent-info
+    </match>
+    
+    <match fluent.warn>
+        type file
+        append true
+        path /appbase/logs/received/fluent-warn
+    </match>
+
+
 ##Parameters
 
 ####type


### PR DESCRIPTION
As a new user coming to the secure documentation for the first time, having a sender-receiver configuration sample on the same page might be additionally useful
