### PR TITLE
"Pretty" format for last_updated.json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ task :last_updated do
     last_updates[lang][File.basename(name, ".txt")] = Time.at((`git log --pretty=%ct --max-count=1 #{path}`.strip).to_i).utc
   }
 
-  File.write("./config/last_updated.json", JSON.dump(last_updates))
+  File.write("./config/last_updated.json", JSON.pretty_generate(last_updates))
 end
 
 desc 'list outdated documents'


### PR DESCRIPTION
We will be able to diff for `last_updated.json` :smile: 

For example, after you have edited the `docs/ja/monitoring.txt` is as follows:
(before)

``` diff
$ git diff
diff --git a/config/last_updated.json b/config/last_updated.json
index 56d9816..8226f85 100644
--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -1 +1 @@
-{"en":{"_buffer_parameters":"2014-11-13 10:40:09 UTC","_formatter_common_parameters":"2014-11-01 22:58:52 UTC","_formatter_parameters":"2014-08-25 19:47:20 UTC","_in_types":"2014-01-27 06:16:26 UTC","_log_level
\ No newline at end of file
+{"en":{"_buffer_parameters":"2014-11-13 10:40:09 UTC","_formatter_common_parameters":"2014-11-01 22:58:52 UTC","_formatter_parameters":"2014-08-25 19:47:20 UTC","_in_types":"2014-01-27 06:16:26 UTC","_log_level
\ No newline at end of file
```

(after)

``` diff
$ git diff
diff --git a/config/last_updated.json b/config/last_updated.json
index f51d226..41517ee 100644
--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -178,7 +178,7 @@
     "logging": "2014-07-27 05:16:17 UTC",
     "logo": "2013-09-22 10:00:29 UTC",
     "mailing-list": "2013-09-22 10:05:34 UTC",
-    "monitoring": "2014-11-17 08:47:25 UTC",
+    "monitoring": "2014-11-18 02:14:11 UTC",
     "nodejs": "2013-01-08 07:22:40 UTC",
     "out_copy": "2014-05-08 14:56:06 UTC",
     "out_exec": "2014-05-07 09:34:51 UTC",
```
