### PR TITLE
Add links to v0.12 new plugins from quickstart

### DIFF
--- a/docs/v0.12/quickstart.txt
+++ b/docs/v0.12/quickstart.txt
@@ -1,1 +1,58 @@
-../quickstart.txt
+# Quickstart Guide
+
+Let's get started with **Fluentd**! **Fluentd** is a fully free and fully open-source log collector that instantly enables you to have a '**Log Everything**' architecture with <a href="http://fluentd.org/plugin/">125+ types of systems</a>.
+
+<center>
+<img src="/images/fluentd-architecture.png" width="450px"/><br /><br />
+</center>
+
+Fluentd treats logs as JSON, a popular machine-readable format. It is written primarily in C with a thin-Ruby wrapper that gives users flexibility.
+
+Fluentd's performance has been proven in the field: its largest user currently collects logs from **5000+ servers**, 5 TB of daily data, handling 50,000 msgs/sec at peak time.
+
+## Step1: Installing Fluentd
+
+Please follow the installation/quickstart guides below that matches your environment.
+
+* [Install Fluentd by RPM package](install-by-rpm) (Redhat Linux)
+* [Install Fluentd by Deb package](install-by-deb) (Ubuntu/Debian Linux)
+* [Install Fluentd by DMG package](install-by-dmg) (Mac OS X)
+* [Install Fluentd by Ruby Gem](install-by-gem)
+* [Install Fluentd by Chef](install-by-chef)
+* [Install Fluentd from source](install-from-source)
+
+NOTE: Fluentd is currently not supported on Windows. Please see <a href="/articles/windows">Collecting Log Data from Windows</a> for details.
+
+## Step2: Use Cases
+
+The articles shown below cover the typical use cases of Fluentd. Please refer to the article(s) that suits your needs.
+
+  * Use Cases
+    * [Data Search like Splunk](free-alternative-to-splunk-by-fluentd)
+    * [Data Filtering and Alerting](splunk-like-grep-and-alert-email)
+    * [Data Analytics with Treasure Data](http-to-td)
+    * [Data Collection to MongoDB](apache-to-mongodb)
+    * [Data Collection to HDFS](http-to-hdfs)
+    * [Data Archiving to Amazon S3](apache-to-s3)
+    * [Windows Event Collection](windows)
+  * Basic Configuration
+    * [Config File](config-file)
+  * Application Logs
+    * [Ruby](ruby), [Java](java), [Python](python), [PHP](php), [Perl](perl), [Node.js](nodejs), [Scala](scala)
+  * Happy Users :)
+    * [Users](users)
+
+## Step3: Learn More
+
+The articles shown below will provide detailed information for you to learn more about Fluentd.
+
+  * [Architecture Overview](architecture)
+  * Plugin Overview
+    * [Input Plugins](input-plugin-overview)
+    * [Output Plugins](output-plugin-overview)
+    * [Buffer Plugins](buffer-plugin-overview)
+    * [Filter Plugins](filter-plugin-overview)
+    * [Parser Plugins](parser-plugin-overview)
+    * [Formatter Plugins](formatter-plugin-overview)
+  * [High Availability Configuration](high-availability)
+  * [FAQ](faq)


### PR DESCRIPTION
Added

```
    * [Filter Plugins](filter-plugin-overview)
    * [Parser Plugins](parser-plugin-overview)
    * [Formatter Plugins](formatter-plugin-overview)
```

BTW, where can I write ja docs for v0.12?
There was no `docs/ja/v0.12` directory, or `docs/v0.12/ja` directory.