### PR TITLE
Fix wrong plugin name in filter_record_transformer's page

### DIFF
--- a/docs/v0.12/filter_record_transformer.txt
+++ b/docs/v0.12/filter_record_transformer.txt
@@ -4,7 +4,7 @@ The `filter_record_transformer` filter plugin mutates/transforms incoming event 
 
 ## Example Configurations
 
-`filter_record_modifier` is included in Fluentd's core. No installation required.
+`filter_record_transformer` is included in Fluentd's core. No installation required.
 
     :::text
     <filter foo.bar>


### PR DESCRIPTION
In /articles/filter_record_transformer, `filter_record_modifier` is present, but it should be `filter_record_transformer`?