### PR TITLE
Update RHEL 7 FAQ

### DIFF
--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -11,8 +11,9 @@ Fluentd v0.10 or v0.12 works on 1.9.3 or later. Since v0.14, 2.1 or later.
 The rubygems of Ruby 2.0-p353 has a deadlock problem ([#9224](https://bugs.ruby-lang.org/issues/9224)).
 If you use Ruby 2.0-p353, upgrading Ruby to latest patch level or Ruby 2.1 resolve this problem.
 
-Unfortunately, Ruby 2.0 package of RHEL 7 and Ubuntu 14.04 use Ruby 2.0-p353.
-So don't use Fluentd with Ruby 2.0 package on these environments.
+Please make sure that you are using either RHEL 7.1 and ruby-2.0.0.598-25.el7_1 package or alternatively you can choose more recent Ruby provided by Red Hat Software Collections (https://access.redhat.com/documentation/en/red-hat-software-collections/)
+
+Unfortunately, Ruby 2.0 package of Ubuntu 14.04 use Ruby 2.0-p353. So don't use Fluentd with Ruby 2.0 package on this environment.
 You can install specified Ruby version using [rbenv](https://github.com/sstephenson/rbenv).
 
 Using td-agent is another way to avoid this problem because td-agent includes own Ruby.


### PR DESCRIPTION
RHEL 7 ships with quite recent version of Ruby, so the note about -p353 is obsolete. Also, RHSCL should be alternative.

BTW, if you encounter such issue, you might want to consider contact Red Hat suppor, if you are RH subscriber or try to report directly in RH bugzilla, such issue won't be ignored.