### PR TITLE
Improve Nginx Error Log regex with multiline mode

### DIFF
--- a/config/last_updated.json
+++ b/config/last_updated.json
@@ -18,7 +18,7 @@
     "cep-norikra": "2014-12-04 17:24:20 UTC",
     "changelog": "2013-11-18 20:27:50 UTC",
     "collect-glusterfs-logs": "2014-11-22 22:16:13 UTC",
-    "common-log-formats": "2014-08-13 18:24:10 UTC",
+    "common-log-formats": "2016-03-01 11:15:50 UTC",
     "community": "2014-02-17 08:00:43 UTC",
     "config-file": "2015-04-10 09:10:01 UTC",
     "failure-scenarios": "2014-02-14 11:01:47 UTC",

--- a/docs/common-log-formats.txt
+++ b/docs/common-log-formats.txt
@@ -25,9 +25,9 @@ This page is a glossary of common log formats that can be parsed with the [Tail 
         </source>
 
     Depending on your particular error log format, you may need to adjust the regular expression above. You can test your format using [Fluentular](http://fluentular.herokuapp.com).
-    
+
 * Maillog
-    
+
     Use a regular expression. See the `format` field in the following sample configuration.
 
         <source>
@@ -49,12 +49,25 @@ This page is a glossary of common log formats that can be parsed with the [Tail 
         </source>
 
 * Nginx Error Log
-    
-    Use a regular expression. See the `format` field in the following sample configuration.
+
+    Use the `format*` and `multiline_flush_interval` fields in the following sample configuration. Applications running under Nginx can output multi-line errors including stack traces, so the multiline mode is a good fit.
 
         <source>
             type tail
-            format /^(?<time>[^ ]+ [^ ]+) \[(?<log_level>.*?)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/
+            tag nginx.error
+            path /var/log/nginx/error.log
+
+            format multiline
+            format_firstline /^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\w+\] (?<pid>\d+).(?<tid>\d+): /
+            format1 /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(?<log_level>\w+)\] (?<pid>\d+).(?<tid>\d+): (?<message>.*)/
+            multiline_flush_interval 3s
+        </source>
+
+    If you know your error log will only contain single lines, you can use the below simpler configuration with just a `format`.
+
+        <source>
+            type tail
+            format /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(?<log_level>\w+)\] (?<pid>\d+).(?<tid>\d+): (?<message>.*)$/
             tag nginx.error
             path /var/log/nginx/error.log
         </source>

--- a/docs/v0.12/common-log-formats.txt
+++ b/docs/v0.12/common-log-formats.txt
@@ -50,11 +50,24 @@ This page is a glossary of common log formats that can be parsed with the [Tail 
 
 * Nginx Error Log
 
-    Use a regular expression. See the `format` field in the following sample configuration.
+    Use the `format*` and `multiline_flush_interval` fields in the following sample configuration. Applications running under Nginx can output multi-line errors including stack traces, so the multiline mode is a good fit.
 
         <source>
             @type tail
-            format /^(?<time>[^ ]+ [^ ]+) \[(?<log_level>.*?)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/
+            tag nginx.error
+            path /var/log/nginx/error.log
+
+            format multiline
+            format_firstline /^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\w+\] (?<pid>\d+).(?<tid>\d+): /
+            format1 /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(?<log_level>\w+)\] (?<pid>\d+).(?<tid>\d+): (?<message>.*)/
+            multiline_flush_interval 3s
+        </source>
+
+    If you know your error log will only contain single lines, you can use the below simpler configuration with just a `format`.
+
+        <source>
+            @type tail
+            format /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(?<log_level>\w+)\] (?<pid>\d+).(?<tid>\d+): (?<message>.*)$/
             tag nginx.error
             path /var/log/nginx/error.log
         </source>


### PR DESCRIPTION
I used the original one for a PHP application and it didn't work so well since the nginx PHP integration would dump multi-line stack traces on each error. The `multiline` format is therefore required for properly parsing the nginx error log.