### PR TITLE
common-log-formats: Fixed the regexp format of nginx/error.log

### DIFF
--- a/docs/common-log-formats.txt
+++ b/docs/common-log-formats.txt
@@ -54,7 +54,7 @@ This page is a glossary of common log formats that can be parsed with the [Tail 
 
         <source>
             type tail
-            format /^(?<time>[^ ]+ [^ ]+) \[(?<log_level>.*)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/
+            format /^(?<time>[^ ]+ [^ ]+) \[(?<log_level>.*?)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/
             tag nginx.error
             path /var/log/nginx/error.log
         </source>

--- a/docs/v0.12/common-log-formats.txt
+++ b/docs/v0.12/common-log-formats.txt
@@ -54,7 +54,7 @@ This page is a glossary of common log formats that can be parsed with the [Tail 
 
         <source>
             @type tail
-            format /^(?<time>[^ ]+ [^ ]+) \[(?<log_level>.*)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/
+            format /^(?<time>[^ ]+ [^ ]+) \[(?<log_level>.*?)\] (?<pid>\d*).(?<tid>[^:]*): (?<message>.*)$/
             tag nginx.error
             path /var/log/nginx/error.log
         </source>


### PR DESCRIPTION
Current sample format can't process [a line including a url with squre bracket](http://fluentular.herokuapp.com/parse?regexp=%5E%28%3F%3Ctime%3E%5B%5E+%5D%2B+%5B%5E+%5D%2B%29+%5C%5B%28%3F%3Clog_level%3E.*%29%5C%5D+%28%3F%3Cpid%3E%5Cd*%29.%28%3F%3Ctid%3E%5B%5E%3A%5D*%29%3A+%28%3F%3Cmessage%3E.*%29%24&input=2016%2F03%2F04+18%3A39%3A05+%5Berror%5D+2264%230%3A+*232080+open%28%29+%22%2Fpath%2Fto%2Fjs%2Fhtml%2Finstream.js+%5B2%5D%22+failed+%282%3A+No+such+file+or+directory%29%2C+client%3A+184.27.179.250%2C+server%3A+example.com%2C+request%3A+%22GET+%2Finstream.js%2520%5B2%5D+HTTP%2F1.1%22%2C+host%3A+%22example.com%22%2C+referrer%3A+%22http%3A%2F%2Fm.dreamers.id%2Flifestyle%2Farticle~3%22&time_format=).

But the square bracket (`[`, `]`) is one of URI characters, according to [RFC3986](https://www.ietf.org/rfc/rfc3986.txt).

Fixed format can capture a same line [properly](http://fluentular.herokuapp.com/parse?regexp=%5E%28%3F%3Ctime%3E%5B%5E+%5D%2B+%5B%5E+%5D%2B%29+%5C%5B%28%3F%3Clog_level%3E.*%3F%29%5C%5D+%28%3F%3Cpid%3E%5Cd*%29.%28%3F%3Ctid%3E%5B%5E%3A%5D*%29%3A+%28%3F%3Cmessage%3E.*%29%24&input=2016%2F03%2F04+18%3A39%3A05+%5Berror%5D+2264%230%3A+*232080+open%28%29+%22%2Fpath%2Fto%2Fjs%2Fhtml%2Finstream.js+%5B2%5D%22+failed+%282%3A+No+such+file+or+directory%29%2C+client%3A+184.27.179.250%2C+server%3A+example.com%2C+request%3A+%22GET+%2Finstream.js%2520%5B2%5D+HTTP%2F1.1%22%2C+host%3A+%22example.com%22%2C+referrer%3A+%22http%3A%2F%2Fm.dreamers.id%2Flifestyle%2Farticle~3%22&time_format=).