### PR TITLE
fix recipe path

### DIFF
--- a/views/category.erb
+++ b/views/category.erb
@@ -11,7 +11,7 @@
     <ul class="articles results">
       <li>
       <% if /^recipe-/.match(name) %>
-        <a href="<%= link_to name.gsub("recipe-", "recipe/").gsub("-to-", "/") %>"><%= title %></a>
+        <a href="<%= link_to "/#{ name.gsub("recipe-", "recipe/").gsub("-to-", "/") }" %>"><%= title %></a>
       <% else %>
         <a href="<%= link_to "/articles/#{slugify(name)}" %>"><%= title %></a>
       <% end %>


### PR DESCRIPTION
All recipes link is broken.
http://docs.fluentd.org/v0.12/categories/recipes

The `link_to` return relative path.
So all recipe a tag attributes is relative path like this `href="recipe/json/treasure-data"`
and this a tag link to http://docs.fluentd.org/v0.12/categories/recipe/json/treasure-data

But this link should be path from root . ( http://docs.fluentd.org/recipe/json/treasure-data ).
So I add / in the top.

