### PR TITLE
fix_typo of time_key

### DIFF
--- a/docs/v0.10/_formatter_common_parameters.txt
+++ b/docs/v0.10/_formatter_common_parameters.txt
@@ -1,6 +1,6 @@
 * **include_time_key** (Boolean, Optional, defaults to false)
   If true, the time field (as specified by the `time_key` parameter) is kept in the record.
-* **time_key** (String, xOptional, defaults to "time")
+* **time_key** (String, Optional, defaults to "time")
   The field name for the time key.
 * **time_format** (String. Optional)
   By default, the output format is iso8601 (e.g. "2008-02-01T21:41:49"). One can specify their own format with this parameter. 

--- a/docs/v0.14/_formatter_common_parameters.txt
+++ b/docs/v0.14/_formatter_common_parameters.txt
@@ -1,6 +1,6 @@
 * **include_time_key** (Boolean, Optional, defaults to false)
   If true, the time field (as specified by the `time_key` parameter) is kept in the record.
-* **time_key** (String, xOptional, defaults to "time")
+* **time_key** (String, Optional, defaults to "time")
   The field name for the time key.
 * **time_format** (String. Optional)
   By default, the output format is iso8601 (e.g. "2008-02-01T21:41:49"). One can specify their own format with this parameter. 


### PR DESCRIPTION
I fixed a typo of `time_key` explanation.
'xOptional' -> 'Optional'