### PR TITLE
Fix nginx.conf

### DIFF
--- a/scripts/conf/input/nginx.conf
+++ b/scripts/conf/input/nginx.conf
@@ -1,7 +1,7 @@
 <source>
   type tail
-  path /var/log/httpd-access.log #...or where you placed your Apache access log
-  pos_file /var/log/td-agent/httpd-access.log.pos # This is where you record file position
+  path /var/log/nginx/access.log #...or where you placed your Nginx access log
+  pos_file /var/log/td-agent/access.log.pos # This is where you record file position
   tag nginx.access #fluentd tag!
   format nginx # Do you have a custom format? You can write your own regex.
 </source>


### PR DESCRIPTION
The example for nginx.conf references the Apache access log instead of the Nginx access log.