### PR TITLE
Drop duplicated occurrence of out_splunk in v0.12 documentation

### DIFF
--- a/lib/toc.en.v0.12.rb
+++ b/lib/toc.en.v0.12.rb
@@ -183,9 +183,6 @@ section 'output-plugins', 'Output Plugins' do
   category 'output-plugin-overview', 'Overview' do
     article 'output-plugin-overview', 'Output Plugin Overview'
   end
-  category 'out_splunk', 'out_splunk' do
-    article 'out_splunk', 'Splunk Enterprise Output Plugin'
-  end
   category 'out_file', 'out_file' do
     article 'out_file', 'file Output Plugin'
   end


### PR DESCRIPTION
![screen shot 2017-08-17 at 13 03 55](https://user-images.githubusercontent.com/3138447/29431381-9c33a3ce-834c-11e7-8b95-d5527e42f019.png)

I found that we have 2 out_splunk links in v0.12 documentation.