### PR TITLE
v0.14: Update toc for out_webhdfs

### DIFF
--- a/lib/toc.en.v0.14.rb
+++ b/lib/toc.en.v0.14.rb
@@ -217,9 +217,9 @@ section 'output-plugins', 'Output Plugins' do
   # category 'out_rewrite_tag_filter', 'out_rewrite_tag_filter' do
   #   article 'out_rewrite_tag_filter', 'rewrite_tag_filter Output Plugin'
   # end
-  # category 'out_webhdfs', 'out_webhdfs' do
-  #   article 'out_webhdfs', 'WebHDFS Output Plugin', ['Hadoop', 'HDFS']
-  # end
+  category 'out_webhdfs', 'out_webhdfs' do
+    article 'out_webhdfs', 'WebHDFS Output Plugin', ['Hadoop', 'HDFS']
+  end
   # category 'out_others', 'Others' do
   #   article 'out_others', 'Other Output Plugins'
   # end


### PR DESCRIPTION
I forgot to update toc when I added out_webhdfs article ( https://github.com/fluent/fluentd-docs/pull/291 ) . So I updated it.