### PR TITLE
fix snippet formatting in forwarding-over-ssl

### DIFF
--- a/docs/v0.10/forwarding-over-ssl.txt
+++ b/docs/v0.10/forwarding-over-ssl.txt
@@ -16,17 +16,17 @@ First, install the secure forward plugin.
 
 Then, set up the configuration file as follows:
 
-	:::text
-	<source>
-	  type secure_forward
-	  shared_key YOUR_SHARED_KEY
-	  self_hostname server.fqdn.local
-	  cert_auto_generate yes
-	</source>
+    :::text
+    <source>
+      type secure_forward
+      shared_key YOUR_SHARED_KEY
+      self_hostname server.fqdn.local
+      cert_auto_generate yes
+    </source>
 
-	<match secure.**>
-	  type stdout
-	</match>
+    <match secure.**>
+      type stdout
+    </match>
 
 The `<match>` clause is there to print out the forwarded message into STDOUT (which is fed into `var/log/td-agent/td-agent.log` for td-agent) using [out_stdout](out_stdout).
 
@@ -42,19 +42,19 @@ First, install the secure forward plugin.
 
 Then, set up the configuration file as follows:
 
-	:::text
-	<source>
-	  type forward
-	</source>
-	<match secure.**>
-		type secure_forward
-		shared_key YOUR_SHARED_KEY
-		self_hostname ${hostname}
-		<server>
-			host RECEIVER_IP
-			port 24284
-		</server>
-	</match>
+    :::text
+    <source>
+      type forward
+    </source>
+    <match secure.**>
+      type secure_forward
+      shared_key YOUR_SHARED_KEY
+      self_hostname ${hostname}
+      <server>
+        host RECEIVER_IP
+        port 24284
+      </server>
+    </match>
 
 The `<source>` clause is there to feed test data into Fluentd using [in_forward](in_forward). Make sure that `YOUR_SHARED_KEY` is same with the receiver's.
 
@@ -64,14 +64,17 @@ Then, (re)start td-agent.
 
 On the sender machine, run the following command using `fluent-cat`
 
-* Fluentd: `echo '{"message":"testing the SSL forwarding"}' | fluent-cat --json secure.test`
-* td-agent v2: `echo '{"message":"testing the SSL forwarding"}' | /opt/td-agent/embedded/bin/fluent-cat --json secure.test`
-* td-agent v1: `echo '{"message":"testing the SSL forwarding"}' | /usr/lib/fluent/ruby/bin/fluent-cat --json secure.test`
+* Fluentd:
+  `echo '{"message":"testing the SSL forwarding"}' | fluent-cat --json secure.test`
+* td-agent v2:
+  `echo '{"message":"testing the SSL forwarding"}' | /opt/td-agent/embedded/bin/fluent-cat --json secure.test`
+* td-agent v1:
+  `echo '{"message":"testing the SSL forwarding"}' | /usr/lib/fluent/ruby/bin/fluent-cat --json secure.test`
 
 Now, checking the receiver's Fluentd's log (for td-agent, this would be `/var/log/td-agent/td-agent.log`), there should be a line like this:
 
-	:::text
-	2014-10-21 18:18:26 -0400 secure.test: {"message":"testing the SSL forwarding"}
+    :::text
+    2014-10-21 18:18:26 -0400 secure.test: {"message":"testing the SSL forwarding"}
 
 ## Resources
 

--- a/docs/v0.12/forwarding-over-ssl.txt
+++ b/docs/v0.12/forwarding-over-ssl.txt
@@ -16,17 +16,17 @@ First, install the secure forward plugin.
 
 Then, set up the configuration file as follows:
 
-	:::text
-	<source>
-         @type secure_forward
-          shared_key YOUR_SHARED_KEY
-          self_hostname server.fqdn.local
-          cert_auto_generate yes
-	</source>
+    :::text
+    <source>
+      @type secure_forward
+      shared_key YOUR_SHARED_KEY
+      self_hostname server.fqdn.local
+      cert_auto_generate yes
+    </source>
 
-	<match secure.**>
-          @type stdout
-	</match>
+    <match secure.**>
+      @type stdout
+    </match>
 
 The `<match>` clause is there to print out the forwarded message into STDOUT (which is fed into `var/log/td-agent/td-agent.log` for td-agent) using [out_stdout](out_stdout).
 
@@ -42,19 +42,20 @@ First, install the secure forward plugin.
 
 Then, set up the configuration file as follows:
 
-       :::text
-        <source>
-          @type forward
-        </source>
-        <match secure.**>
-          @type secure_forward
-          shared_key YOUR_SHARED_KEY
-          self_hostname "#{Socket.gethostname}"
-          <server>
-            host RECEIVER_IP
-            port 24284
-          </server>
-	</match>
+    :::text
+    <source>
+      @type forward
+    </source>
+
+    <match secure.**>
+      @type secure_forward
+      shared_key YOUR_SHARED_KEY
+      self_hostname "#{Socket.gethostname}"
+      <server>
+        host RECEIVER_IP
+        port 24284
+      </server>
+    </match>
 
 The `<source>` clause is there to feed test data into Fluentd using [in_forward](in_forward). Make sure that `YOUR_SHARED_KEY` is same with the receiver's.
 
@@ -64,14 +65,17 @@ Then, (re)start td-agent.
 
 On the sender machine, run the following command using `fluent-cat`
 
-* Fluentd: `echo '{"message":"testing the SSL forwarding"}' | fluent-cat --json secure.test`
-* td-agent v2: `echo '{"message":"testing the SSL forwarding"}' | /opt/td-agent/embedded/bin/fluent-cat --json secure.test`
-* td-agent v1: `echo '{"message":"testing the SSL forwarding"}' | /usr/lib/fluent/ruby/bin/fluent-cat --json secure.test`
+* Fluentd:
+  `echo '{"message":"testing the SSL forwarding"}' | fluent-cat --json secure.test`
+* td-agent v2:
+  `echo '{"message":"testing the SSL forwarding"}' | /opt/td-agent/embedded/bin/fluent-cat --json secure.test`
+* td-agent v1:
+  `echo '{"message":"testing the SSL forwarding"}' | /usr/lib/fluent/ruby/bin/fluent-cat --json secure.test`
 
 Now, checking the receiver's Fluentd's log (for td-agent, this would be `/var/log/td-agent/td-agent.log`), there should be a line like this:
 
-	:::text
-	2014-10-21 18:18:26 -0400 secure.test: {"message":"testing the SSL forwarding"}
+    :::text
+    2014-10-21 18:18:26 -0400 secure.test: {"message":"testing the SSL forwarding"}
 
 ## Resources
 


### PR DESCRIPTION
e.g. https://docs.fluentd.org/v0.12/articles/forwarding-over-ssl#setup:-sender