### PR TITLE
We can improve Run example.

### DIFF
--- a/docs/v0.14/install-by-gem.txt
+++ b/docs/v0.14/install-by-gem.txt
@@ -29,6 +29,7 @@ Run the following commands to confirm that Fluentd was installed successfully:
     $ fluentd -c ./fluent/fluent.conf -vv &
     $ echo '{"json":"message"}' | fluent-cat debug.test
 
+The second command start Fluentd daemon in background. If you want to stop daemon, you can use `$ pkill -f fluentd`.
 The last command sends Fluentd a message ‘{“json”:”message”}’ with a “debug.test” tag. If the installation was successful, Fluentd will output the following message:
 
     :::term

--- a/docs/v0.14/install-from-source.txt
+++ b/docs/v0.14/install-from-source.txt
@@ -39,6 +39,7 @@ Run the following commands to to confirm that Fluentd was installed successfully
     $ fluentd -c ./fluent/fluent.conf -vv &
     $ echo '{"json":"message"}' | fluent-cat debug.test
 
+The second command start Fluentd daemon in background. If you want to stop daemon, you can use `$ pkill -f fluentd`.
 The last command sends Fluentd a message ‘{“json”:”message”}’ with a “debug.test” tag. If the installation was successful, Fluentd will output the following message:
 
     :::term


### PR DESCRIPTION
We can add explanation of `$ fluentd -c ./fluent/fluent.conf -vv &`. When I run this command, I confused because this logs show me what? Is this building now? So, we promote users to next step.

Finally, We can't stop fluentd process by `Ctrl + C` . Let's write how to exit.
For example `$ pkill -f fluentd`