### PR TITLE
Add Debian Stretch entry to supported platforms table

### DIFF
--- a/docs/v0.14/td-agent-v2-vs-v3.txt
+++ b/docs/v0.14/td-agent-v2-vs-v3.txt
@@ -15,6 +15,7 @@
         <tr><td>Ubuntu Xenial</td><td>&#10003;</td><td>&#10003;</td></tr>
 	<tr><td>Debian Wheezy</td><td>&#10003;</td><td></td></tr>
        	<tr><td>Debian Jessie</td><td>&#10003;</td><td>*</td></tr>
+	<tr><td>Debian Stretch</td><td>&#10003;</td><td>*</td></tr>
 	<tr><td>MacOSX</td><td>&#10003;</td><td>*</td></tr>
        	<tr><td>Windows</td><td></td><td>&#10003;</td></tr>
 </table>

--- a/docs/v0.14/td-agent-v2-vs-v3.txt
+++ b/docs/v0.14/td-agent-v2-vs-v3.txt
@@ -14,8 +14,8 @@
 	<tr><td>Ubuntu Trusty</td><td>&#10003;</td><td>&#10003;</td></tr>
         <tr><td>Ubuntu Xenial</td><td>&#10003;</td><td>&#10003;</td></tr>
 	<tr><td>Debian Wheezy</td><td>&#10003;</td><td></td></tr>
-       	<tr><td>Debian Jessie</td><td>&#10003;</td><td>*</td></tr>
-	<tr><td>Debian Stretch</td><td>&#10003;</td><td>*</td></tr>
+		<tr><td>Debian Jessie</td><td>&#10003;</td><td>&#10003;</td></tr>
+	<tr><td>Debian Stretch</td><td>&#10003;</td><td>&#10003;</td></tr>
 	<tr><td>MacOSX</td><td>&#10003;</td><td>*</td></tr>
        	<tr><td>Windows</td><td></td><td>&#10003;</td></tr>
 </table>


### PR DESCRIPTION
Currently, td-agent v2 had been released for Debian Stretch.
But td-agent v3 is not released yet for it.