### PR TITLE
Fix some minor typos

### DIFF
--- a/docs/v0.14/buffer-plugin-overview.txt
+++ b/docs/v0.14/buffer-plugin-overview.txt
@@ -2,7 +2,7 @@
 
 NOTE: This page is simply copied from LINK(v0.12):[v0.12 documents](/articles/buffer-plugin-overview), and will be updated later.
 
-Fluentd has 6 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Buffer Plugin.
+Fluentd has 7 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Buffer Plugin.
 
 ## Buffer Plugin Overview
 

--- a/docs/v0.14/buffer-section.txt
+++ b/docs/v0.14/buffer-section.txt
@@ -261,7 +261,7 @@ These parameters below are to configure buffer plugins and its chunks.
 * ``chunk_full_threshold`` [float]
   * Default: 0.95
   * The percentage of chunk size threshold for flushing
-  * output plugin will flush the chunk when actual size reaches ``chunk_size_limit * chunk_full_threshold (== 8MB * 0.95 in default)``
+  * output plugin will flush the chunk when actual size reaches ``chunk_limit_size * chunk_full_threshold (== 8MB * 0.95 in default)``
 * ``compress`` [enum: text/gzip]
   * Default: text
   * The option to specify compression of each chunks, during events are buffered

--- a/docs/v0.14/filter-plugin-overview.txt
+++ b/docs/v0.14/filter-plugin-overview.txt
@@ -1,6 +1,6 @@
 # Filter Plugin Overview
 
-Fluentd has 6 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Filter Plugin.
+Fluentd has 7 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Filter Plugin.
 
 ## Overview
 

--- a/docs/v0.14/input-plugin-overview.txt
+++ b/docs/v0.14/input-plugin-overview.txt
@@ -1,6 +1,6 @@
 # Input Plugin Overview
 
-Fluentd has 6 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Input Plugin.
+Fluentd has 7 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Input Plugin.
 
 ## Overview
 

--- a/docs/v0.14/output-plugin-overview.txt
+++ b/docs/v0.14/output-plugin-overview.txt
@@ -1,6 +1,6 @@
 # Output Plugin Overview
 
-Fluentd has 6 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Output Plugin.
+Fluentd has 7 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Output Plugin.
 
 ## Overview
 

--- a/docs/v0.14/parser-plugin-overview.txt
+++ b/docs/v0.14/parser-plugin-overview.txt
@@ -1,6 +1,6 @@
 # Parser Plugin Overview
 
-Fluentd has 6 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Parser Plugin.
+Fluentd has 7 types of plugins: [Input](input-plugin-overview), [Parser](parser-plugin-overview), [Filter](filter-plugin-overview), [Output](output-plugin-overview), [Formatter](formatter-plugin-overview), [Storage](storage-plugin-overview) and [Buffer](buffer-plugin-overview). This article gives an overview of Parser Plugin.
 
 ## Overview
 

--- a/docs/v0.14/performance-tuning.txt
+++ b/docs/v0.14/performance-tuning.txt
@@ -72,9 +72,9 @@ See [Ruby 2.1 Garbage Collection: ready for production](https://samsaffron.com/a
 
 The CPU is often the bottleneck for Fluentd instances that handle billions of incoming records. To utilize multiple CPU cores, we recommend using `multi workers` feature.
 
-   :::text
-   <system>
-     workers 8
-   </system>
+    :::text
+    <system>
+      workers 8
+    </system>
 
 * [multi workers](system-config#workers)


### PR DESCRIPTION
A bit more precisely:
* Fix number of plugin types
* Fix badly displayed 'workers' example
* Fix bad parameter name
