### PR TITLE
Add out_mongo document for v1.0

### DIFF
--- a/docs/v1.0/out_mongo.txt
+++ b/docs/v1.0/out_mongo.txt
@@ -15,7 +15,7 @@ Fluentd enables your apps to insert records to MongoDB asynchronously with batch
 
 ## Install
 
-`out_geoip` is not included in td-agent by default. Fluentd gem users will need to install the fluent-plugin-mongo gem using the following command.
+`out_mongo` is not included in td-agent by default. Fluentd gem users will need to install the fluent-plugin-mongo gem using the following command.
 
     :::term
     $ fluent-gem install fluent-plugin-mongo

--- a/docs/v1.0/out_mongo.txt
+++ b/docs/v1.0/out_mongo.txt
@@ -40,11 +40,15 @@ For more details, see [Plugin Management](plugin-management).
       user michael
       password jordan
 
-      # key name of timestamp
-      time_key time
+      <inject>
+        # key name of timestamp
+        time_key time
+      </inject>
 
-      # flush
-      flush_interval 10s
+      <buffer>
+        # flush
+        flush_interval 10s
+      </buffer>
     </match>
 
 Please see the [Store Apache Logs into MongoDB](apache-to-mongodb) article for real-world use cases.

--- a/docs/v1.0/out_mongo.txt
+++ b/docs/v1.0/out_mongo.txt
@@ -1,0 +1,165 @@
+# MongoDB Output Plugin
+
+The `out_mongo` Output plugin writes records into [MongoDB](http://mongodb.org/), the emerging document-oriented database system.
+
+NOTE: If you're using ReplicaSet, please see the <a href="out_mongo_replset">out_mongo_replset</a> article instead.
+
+NOTE: This document doesn't describe all parameters. If you want to know full features, check the Further Reading section.
+
+## Why Fluentd with MongoDB?
+
+Fluentd enables your apps to insert records to MongoDB asynchronously with batch-insertion, unlike direct insertion of records from your apps. This has the following advantages:
+
+1. less impact on application performance
+2. higher MongoDB insertion throughput while maintaining JSON record structure
+
+## Install
+
+`out_geoip` is not included in td-agent by default. Fluentd gem users will need to install the fluent-plugin-mongo gem using the following command.
+
+    :::term
+    $ fluent-gem install fluent-plugin-mongo
+
+For more details, see [Plugin Management](plugin-management).
+
+## Example Configuration
+
+    # Single MongoDB
+    <match mongo.**>
+      @type mongo
+      host fluentd
+      port 27017
+      database fluentd
+      collection test
+
+      # for capped collection
+      capped
+      capped_size 1024m
+
+      # authentication
+      user michael
+      password jordan
+
+      # key name of timestamp
+      time_key time
+
+      # flush
+      flush_interval 10s
+    </match>
+
+Please see the [Store Apache Logs into MongoDB](apache-to-mongodb) article for real-world use cases.
+
+NOTE: Please see the <a href="config-file">Config File</a> article for the basic structure and syntax of the configuration file.
+
+## Parameters
+
+### type
+
+The value must be `mongo`.
+
+### host
+
+| type   | default     | version |
+|:------:|:-----------:|:-------:|
+| string | 'localhost' | 1.0.0   |
+
+The MongoDB hostname.
+
+### port (required)
+
+| type    | default | version |
+|:-------:|:-------:|:-------:|
+| integer | 27017   | 1.0.0   |
+
+The MongoDB port.
+
+### database
+
+| type   | default            | version |
+|:------:|:------------------:|:-------:|
+| string | required parameter | 1.0.0   |
+
+The database name.
+
+### collection (required, if not tag_mapped)
+
+| type   | default                                              | version |
+|:------:|:----------------------------------------------------:|:-------:|
+| string | 'untagged' or required parameter if not `tag_mapped` | 1.0.0   |
+
+The collection name.
+
+### capped
+
+| type   | default  | version |
+|:------:|:--------:|:-------:|
+| string | optional | 1.0.0   |
+
+This option enables capped collection. This is always recommended because MongoDB is not suited to storing large amounts of historical data.
+
+#### capped_size
+
+| type   | default  | version |
+|:------:|:--------:|:-------:|
+| size   | optional | 1.0.0   |
+
+Sets the capped collection size.
+
+### user
+
+| type   | default | version |
+|:------:|:-------:|:-------:|
+| string |  `nil`  | 1.0.0   |
+
+The username to use for authentication.
+
+### password
+
+| type   | default  | version |
+|:------:|:--------:|:-------:|
+| string |  `nil`   | 1.0.0   |
+
+The password to use for authentication.
+
+### time_key
+
+| type   | default  | version |
+|:------:|:--------:|:-------:|
+| string | `time`   | 1.0.0   |
+
+The key name of timestamp. (default is "time")
+
+### tag_mapped
+
+| type   | default  | version |
+|:------:|:--------:|:-------:|
+| bool   |  `false` | 1.0.0   |
+
+This option will allow out_mongo to use Fluentd's tag to determine the destination collection. For example, if you generate records with tags 'mongo.foo', the records will be inserted into the `foo` collection within the `fluentd` database.
+
+    :::text
+    <match mongo.*>
+      @type mongo
+      host fluentd
+      port 27017
+      database fluentd
+
+      # Set 'tag_mapped' if you want to use tag mapped mode.
+      tag_mapped
+
+      # If the tag is "mongo.foo", then the prefix "mongo." is removed.
+      # The inserted collection name is "foo".
+      remove_tag_prefix mongo.
+
+      # This configuration is used if the tag is not found. The default is 'untagged'.
+      collection misc
+    </match>
+
+This option is useful for flexible log collection.
+
+## Common Buffer / Output parameters
+See [Buffer Plugin Overview](buffer-plugin-overview) and [Output Plugin Overview](output-plugin-overview)
+
+
+## Further Reading
+- [fluent-plugin-mongo repository](https://github.com/fluent/fluent-plugin-mongo)

--- a/lib/toc.en.v1.0.rb
+++ b/lib/toc.en.v1.0.rb
@@ -199,9 +199,9 @@ section 'output-plugins', 'Output Plugins' do
   category 'out_s3', 'out_s3' do
     article 'out_s3', 'S3 Output Plugin', ['Amazon S3', 'AWS', 'Simple Storage Service']
   end
-  # category 'out_mongo', 'out_mongo' do
-  #   article 'out_mongo', 'MongoDB Output Plugin', ['MongoDB']
-  # end
+  category 'out_mongo', 'out_mongo' do
+    article 'out_mongo', 'MongoDB Output Plugin', ['MongoDB']
+  end
   # category 'out_mongo_replset', 'out_mongo_replset' do
   #   article 'out_mongo_replset', 'MongoDB ReplicaSet Output Plugin', ['MongoDB', 'Mongo']
   # end


### PR DESCRIPTION
v0.14/v1.0 ready out_mongo plugin is version 1.0.0.
Users should use fluent-plugin-mongo v1.0.0 when they use td-agent3/Fluentd v0.14 or v1.0.
So, I use `1.0.0` in introduced version.