### PR TITLE
docs: Use a less confusing page title.

### DIFF
--- a/docs/v1.0/life-of-a-fluentd-event.txt
+++ b/docs/v1.0/life-of-a-fluentd-event.txt
@@ -1,4 +1,4 @@
-# Configuration File
+# Life of a Fluentd event
 
 The following article describe a global overview of how events are processed by [Fluentd](http://fluentd.org) using examples. It covers the complete cycle including _Setup_, _Inputs_, _Filters_, _Matches_ and _Labels_.
 


### PR DESCRIPTION
The document which explains how fluentd processes various events
has a fairly confusing title ("Configulation File").

> https://docs.fluentd.org/v1.0/articles/life-of-a-fluentd-event

This patch fixes its title to be more descriptive.