### PR TITLE
docs: fix singular/plural forms

### DIFF
--- a/docs/v1.0/life-of-a-fluentd-event.txt
+++ b/docs/v1.0/life-of-a-fluentd-event.txt
@@ -4,7 +4,7 @@ The following article describe a global overview of how events are processed by 
 
 ## Basic Setup
 
-The configuration files is the fundamental piece to connect all things together, as it allows to define which _Inputs_ or listeners [Fluentd](http://fluentd.org) will have and setup common matching rules to route the _Event_ data to a specific _Output_.
+The configuration file is the fundamental piece to connect all things together, as it allows to define which _Inputs_ or listeners [Fluentd](http://fluentd.org) will have and setup common matching rules to route the _Event_ data to a specific _Output_.
 
 We will use the [in_http](in_http) and the [out_stdout](out_stdout) plugins as examples to describe the events cycle. The following is a basic definition on the configuration file to specify an _http_ input, for short: we will be listening for __HTTP Requests__:
 


### PR DESCRIPTION
This patch removes 's' from 'files' to make the subject match the verb.
