### PR TITLE
docs: use 'systemctl restart' to restart a process

### DIFF
--- a/docs/v1.0/java.txt
+++ b/docs/v1.0/java.txt
@@ -38,7 +38,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using fluent-logger-java
 

--- a/docs/v1.0/nodejs.txt
+++ b/docs/v1.0/nodejs.txt
@@ -38,7 +38,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using fluent-logger-node
 

--- a/docs/v1.0/perl.txt
+++ b/docs/v1.0/perl.txt
@@ -38,7 +38,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using Fluent::Logger
 

--- a/docs/v1.0/php.txt
+++ b/docs/v1.0/php.txt
@@ -39,7 +39,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using fluent-logger-php
 

--- a/docs/v1.0/python.txt
+++ b/docs/v1.0/python.txt
@@ -38,7 +38,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using fluent-logger-python
 

--- a/docs/v1.0/ruby.txt
+++ b/docs/v1.0/ruby.txt
@@ -38,7 +38,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using fluent-logger-ruby
 

--- a/docs/v1.0/scala.txt
+++ b/docs/v1.0/scala.txt
@@ -39,7 +39,7 @@ Please restart your agent once these lines are in place.
     # for rpm/deb only
     $ sudo /etc/init.d/td-agent restart
     # or systemd
-    $ sudo systemctl start td-agent.service
+    $ sudo systemctl restart td-agent.service
 
 ## Using fluent-logger-scala
 


### PR DESCRIPTION
The current manual instructs users to use the following command
for restarting a process:

> $ sudo systemctl start td-agent.service

But `systemctl start` will do nothing if the target process is
already runnning. Instead, we should use the `restart` command.