### PR TITLE
views: Adjust the z-index of the `got-question` popup.

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -147,7 +147,7 @@
       </div><!-- /#category -->
     </div><!-- /.wrapper -->
     <div id="got-question"
-      style="opacity:0; position:fixed;top:0;left:0;width:280px;height:50px;background-color:#FFFFFF;border:1px solid #FF5F5F">
+      style="opacity:0; position:fixed;top:0;left:0;width:280px;height:50px;background-color:#FFFFFF;border:1px solid #FF5F5F; z-index:2;">
       <a href="//www.fluentd.org/newsletter">
       <div style="margin:8px auto; width:200px; text-align:center;font-size:14px;">
         <span style="color:#ff5f5f">Interested in the Fluentd Newsletters?</span>


### PR DESCRIPTION
### Problem

Without z-index styling, the popup can be overlaid by the normal elements in the page.
This leads to an odd UI elements arrangement.

For example, look at the screenshot below:

![2017-12-19-101708_378x83_scrot](https://user-images.githubusercontent.com/8974561/34144045-29963924-e4d3-11e7-906e-23373ac5d371.png)

### Solution

This patch sets z-index of the popup, so that it gets always stacked on the other elements.
After this commit, the popup will look like:

![2017-12-19-155517_379x75_scrot](https://user-images.githubusercontent.com/8974561/34144476-087a52be-e4d5-11e7-9ccd-ec52a8d7a019.png)
