### PR TITLE
Add a missing instruction for systemd users.

### DIFF
--- a/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
@@ -126,7 +126,10 @@ In our final step, we'll forward the logs from your rsyslogd to Fluentd. Please 
 Please restart the rsyslog service once the modification is complete.
 
     :::text
+    # init
     $ sudo /etc/init.d/rsyslog restart
+    # or systemd
+    $ sudo systemctl restart rsyslog
 
 ## Store and Search Event Logs
 


### PR DESCRIPTION
This is a small patch that adds a code example to restart rsyslogd
using `systemctl(1)`.

Since the other parts of this document contains instructions for
systemd users, it's natural to expect this part also contains one.

### Screenshot

Here is how it looks like after this patch:

![2017-12-20-141616_832x173_scrot](https://user-images.githubusercontent.com/8974561/34192275-5db5bcd0-e590-11e7-8158-d97409f0b57d.png)
