### PR TITLE
docs: Fix a typo (Dowload -> Download)

### DIFF
--- a/docs/v0.10/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v0.10/free-alternative-to-splunk-by-fluentd.txt
@@ -56,7 +56,7 @@ Once installation is complete, start Elasticsearch.
 ## Set Up Kibana
 
 To install Kibana, download it via the official webpage and extract it. Kibana is a HTML / CSS / JavaScript application.
-Dowload page is [here](https://www.elastic.co/downloads/kibana). In this article, we download Mac OS X binary.
+Download page is [here](https://www.elastic.co/downloads/kibana). In this article, we download Mac OS X binary.
 
     :::term
     $ curl -O https://download.elastic.co/kibana/kibana/kibana-4.1.1-darwin-x64.tar.gz

--- a/docs/v0.12/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v0.12/free-alternative-to-splunk-by-fluentd.txt
@@ -56,7 +56,7 @@ Once installation is complete, start Elasticsearch.
 ## Set Up Kibana
 
 To install Kibana, download it via the official webpage and extract it. Kibana is a HTML / CSS / JavaScript application.
-Dowload page is [here](https://www.elastic.co/downloads/kibana). In this article, we download Mac OS X binary.
+Download page is [here](https://www.elastic.co/downloads/kibana). In this article, we download Mac OS X binary.
 
     :::term
     $ curl -O https://artifacts.elastic.co/downloads/kibana/kibana-5.0.2-darwin-x86_64.tar.gz

--- a/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
@@ -56,7 +56,7 @@ Once installation is complete, start Elasticsearch.
 ## Set Up Kibana
 
 To install Kibana, download it via the official webpage and extract it. Kibana is a HTML / CSS / JavaScript application.
-Dowload page is [here](https://www.elastic.co/downloads/kibana). In this article, we download Mac OS X binary.
+Download page is [here](https://www.elastic.co/downloads/kibana). In this article, we download Mac OS X binary.
 
     :::term
     $ curl -O https://artifacts.elastic.co/downloads/kibana/kibana-5.0.2-darwin-x86_64.tar.gz


### PR DESCRIPTION
This patch fixes a subtle typo in the manual.

This commit also includes  fixes for the old revisions of this document
(namely v0.10 and v0.12)