### PR TITLE
docs: Fix the outdated links to 'fluentd.treasuredata.com'

### DIFF
--- a/docs/v0.10/enterprise-support-portal.txt
+++ b/docs/v0.10/enterprise-support-portal.txt
@@ -1,6 +1,6 @@
 # Fluentd Enterprise Support Portal
 
-This article describes the Enterprise support program provided by [Treasure Data](http://fluentd.treasuredata.com).
+This article describes the Enterprise support program provided by [Treasure Data](https://www.treasuredata.com/fluentd/).
 
 > If you are a Fluentd Service provider wanting to get listed here, please refer to the [ENTERPRISE PROVIDER](https://github.com/fluent/fluentd/blob/master/ENTERPRISE_PROVIDERS.md) guidelines
 

--- a/docs/v0.10/support.txt
+++ b/docs/v0.10/support.txt
@@ -16,4 +16,4 @@ Join our Slack channel and talk with Fluentd developers and users directly, now.
 
 Treasure Data, the original inventor of Fluentd, offers 24/7 support with SLA. Please visit the link below for more details.
 
-- [Fluentd Enterprise Edition](https://fluentd.treasuredata.com/)
+- [Fluentd Enterprise Edition](https://www.treasuredata.com/fluentd/)

--- a/docs/v0.12/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v0.12/free-alternative-to-splunk-by-fluentd.txt
@@ -155,7 +155,7 @@ If you will be using these components in production, you may want to modify some
 
 ## Fluentd Enterprise for Splunk Users
 
-Treasure Data, the creator of Fluentd, offers Fluentd Enterprise. If you are looking to optimize your Splunk setup, [learn more here](https://fluentd.treasuredata.com/splunk-optimize/).
+Treasure Data, the creator of Fluentd, offers Fluentd Enterprise. If you are looking to optimize your Splunk setup, [learn more here](https://www.treasuredata.com/fluentd/splunk-optimize/).
 
 ## Learn More
 

--- a/docs/v0.12/kubernetes-fluentd.txt
+++ b/docs/v0.12/kubernetes-fluentd.txt
@@ -90,4 +90,4 @@ Any relevant change needs to be done to the Yaml file before to deploy it. Using
 
 ## Enterprise Support by Treasure Data
 
-Treasure Data, the original creator of Fluentd, [offers commercial support for Fluentd on Kubernetes](https://fluentd.treasuredata.com/kubernetes-logging/).
+Treasure Data, the original creator of Fluentd, [offers commercial support for Fluentd on Kubernetes](https://www.treasuredata.com/fluentd/kubernetes-logging/).

--- a/docs/v1.0/enterprise-support-portal.txt
+++ b/docs/v1.0/enterprise-support-portal.txt
@@ -1,6 +1,6 @@
 # Fluentd Enterprise Support Portal
 
-This article describes the Enterprise support program provided by [Treasure Data](http://fluentd.treasuredata.com).
+This article describes the Enterprise support program provided by [Treasure Data](https://www.treasuredata.com/fluentd/).
 
 > If you are a Fluentd Service provider wanting to get listed here, please refer to the [ENTERPRISE PROVIDER](https://github.com/fluent/fluentd/blob/master/ENTERPRISE_PROVIDERS.md) guidelines
 

--- a/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
@@ -162,7 +162,7 @@ If you will be using these components in production, you may want to modify some
 
 ## Fluentd Enterprise for Splunk Users
 
-Treasure Data, the creator of Fluentd, offers Fluentd Enterprise. If you are looking to optimize your Splunk setup, [learn more here](https://fluentd.treasuredata.com/splunk-optimize/).
+Treasure Data, the creator of Fluentd, offers Fluentd Enterprise. If you are looking to optimize your Splunk setup, [learn more here](https://www.treasuredata.com/fluentd/splunk-optimize/).
 
 ## Learn More
 

--- a/docs/v1.0/support.txt
+++ b/docs/v1.0/support.txt
@@ -16,4 +16,4 @@ Join our Slack channel and talk with Fluentd developers and users directly, now.
 
 Treasure Data, the original inventor of Fluentd, offers 24/7 support with SLA. Please visit the link below for more details.
 
-- [Fluentd Enterprise Edition](https://fluentd.treasuredata.com/)
+- [Fluentd Enterprise Edition](https://www.treasuredata.com/fluentd/)


### PR DESCRIPTION
### What is this patch

The official website 'fluentd.treasuredata.com' has been moved to
'www.treasuredata.com/fluentd/'. This migration made several links
in the manual pages broken.

For instance, we need to fix a link to Splunk article as follows:

* old: https://fluentd.treasuredata.com/splunk-optimize/
* new: https://www.treasuredata.com/fluentd/splunk-optimize/

This patch updates all these links to 'fluentd.treasuredata.com'.