### PR TITLE
app: Make "What is fluentd?" button look nice

### DIFF
--- a/app/css/base.css
+++ b/app/css/base.css
@@ -1146,7 +1146,6 @@ del.differ, del.differ * {
 	-webkit-border-radius: 23px;
 	width:174px;
 	padding:4px 18px 4px 10px;
-	color:#fff;
 	text-transform:uppercase;
 	text-align:center;
 	box-shadow: 1px 1px 1px #fff;
@@ -1154,6 +1153,9 @@ del.differ, del.differ * {
 	-moz-box-shadow: 1px 1px 1px #fff;
 	background:#da4808 url(/images/arrow01.png) 90% 50% no-repeat;
 }
+.btn-look a {
+    color: #ffffff;
+}
 .btn-look a:visited {
-  color: #ffffff;
+    color: #ffffff;
 }


### PR DESCRIPTION
### Problem

For now, the 'color' directive in the `.btn-look` selector has no effect on the actual appearance of the buttons, because it gets overridden by the common color settings of `<a>` tag. This leads to somewhat odd-looking buttons.

This patch fixes the styling definition to make these buttons look more readable.

### Screenshot
Here is how it looks like now:

![2017-12-20-185113_428x90_scrot](https://user-images.githubusercontent.com/8974561/34201124-db553dde-e5b6-11e7-9aca-e828699e7c82.png)

...and after this patch:

![2017-12-20-185122_420x93_scrot](https://user-images.githubusercontent.com/8974561/34201133-e19e9dde-e5b6-11e7-8478-388f19d7a2c5.png)
