### PR TITLE
views: Use `display: none;` to make hidden popups unclickable.

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -147,7 +147,7 @@
       </div><!-- /#category -->
     </div><!-- /.wrapper -->
     <div id="got-question"
-      style="opacity:0; position:fixed;top:0;left:0;width:280px;height:50px;background-color:#FFFFFF;border:1px solid #FF5F5F; z-index:2;">
+      style="display:none;position:fixed;top:0;left:0;width:280px;height:50px;background-color:#FFFFFF;border:1px solid #FF5F5F;z-index:2;">
       <a href="//www.fluentd.org/newsletter">
       <div style="margin:8px auto; width:200px; text-align:center;font-size:14px;">
         <span style="color:#ff5f5f">Interested in the Fluentd Newsletters?</span>
@@ -155,7 +155,7 @@
       </div>
     </div>
     <div id="anchored-stargazer-count"
-      style="opacity:0; position:fixed;top:52px;left:189px;width:110px;height:20px;">
+      style="display:none;position:fixed;top:52px;left:189px;width:110px;height:20px;">
       <iframe src="https://ghbtns.com/github-btn.html?user=fluent&repo=fluentd&type=watch&count=true"
             allowtransparency="true" frameborder="0" scrolling="0" width="110px"
             height="20px"></iframe>
@@ -165,9 +165,10 @@
   <script>
     $(document).ready(function() {
         $(window).scroll(function() {
-          var link_opacity = window.pageYOffset > 700 ? 1.0 : 0;
-          $('#got-question').css('opacity', link_opacity);
+          var display = window.pageYOffset > 700 ? 'block' : 'none';
+          $('#got-question').css('display', display);
         });
+
         $('#got-question').hover(function(){
           $(this).css('background-color', '#FF5F5F');
           $('#got-question span').css('color', '#FFFFFF');
@@ -177,8 +178,8 @@
         });
 
         $(window).scroll(function() {
-          var link_opacity = window.pageYOffset > 700 ? 1.0 : 0;
-          $('#anchored-stargazer-count').css('opacity', link_opacity);
+          var display = window.pageYOffset > 700 ? 'block' : 'none';
+          $('#anchored-stargazer-count').css('display', display);
         });
     })
   </script>


### PR DESCRIPTION
This patch fixes the bug reported by #258.

### What is the problem?

Currently, we use "opacity" attribute to hide the newsletter popups in the left-top corner.
For example, we specify `opacity: 0;` to make these popups invisible.

This leads to, however, somewhat confusing UI, because these popups remain clickable
even if they are in the "hidden" state:

![invisible](https://user-images.githubusercontent.com/8974561/34284698-4d2bac3e-e717-11e7-8a27-b98ae54362ea.png)


### How to fix these popups

Instead, we should use `display: none;` to make these popups invisible.

This setting should make these popups unclickable (if they are in the "hidden" state),
hence will prevent users from clicking them accidentally.