### PR TITLE
doc: Fix a broken link to '/categories/recipes'

### DIFF
--- a/docs/v0.12/splunk-like-grep-and-alert-email.txt
+++ b/docs/v0.12/splunk-like-grep-and-alert-email.txt
@@ -112,6 +112,6 @@ Admittedly, this is a contrived example. In reality, you would set the threshold
 You can learn more about Fluentd and its plugins by
 
 - exploring other [plugins](http://fluentd.org/plugin/)
-- browsing [recipes](/categories/recipes)
+- browsing [recipes](/v0.12/categories/recipes)
 - asking questions on the [mailing list](https://groups.google.com/forum/#!forum/fluentd)
 - <a href="//www.fluentd.org/newsletter">signing up for our newsletters</a>

--- a/docs/v1.0/splunk-like-grep-and-alert-email.txt
+++ b/docs/v1.0/splunk-like-grep-and-alert-email.txt
@@ -114,6 +114,5 @@ Admittedly, this is a contrived example. In reality, you would set the threshold
 You can learn more about Fluentd and its plugins by
 
 - exploring other [plugins](http://fluentd.org/plugin/)
-- browsing [recipes](/categories/recipes)
 - asking questions on the [mailing list](https://groups.google.com/forum/#!forum/fluentd)
 - <a href="//www.fluentd.org/newsletter">signing up for our newsletters</a>


### PR DESCRIPTION
For now, the "browsing recipes" link does not work properly, and it
leads users to a non-existent page (in any version of the document).

The reason behind this issue is a bit entangled:

 - In v1.0 docs, the "recipes" page is disabled, and thus, does not exist.

 - In v0.12 docs, the page *does* exist. But the URL is wrongly pointing to '/v1.0/categories/recipes'.

So I fixed the link as follows:

 - For v1.0, just delete the link.
 - For v0.12, fix the url to point to '/v0.12/categories/recipes'