### PR TITLE
 docs: Use TD_AGENT_OPTIONS to turn on a debug flag. 

### DIFF
--- a/docs/v0.12/trouble-shooting.txt
+++ b/docs/v0.12/trouble-shooting.txt
@@ -1,1 +1,75 @@
-../v0.10/trouble-shooting.txt
+# Troubleshooting Fluentd
+
+## Look at Logs
+
+If things aren't happening as expected, please first look at your logs. For td-agent (rpm/deb), the logs are located at `/var/log/td-agent/td-agent.log`.
+
+## Turn on Verbose Logging
+
+You can get more information about the logs if verbose logging is turned on. Please follow the steps below.
+
+### rpm
+
+1. edit `/etc/init.d/td-agent`
+2. add `-vv` to TD_AGENT_ARGS
+3. restart td-agent
+
+       :::text
+       # at /etc/init.d/td-agent
+       ...
+       TD_AGENT_ARGS="... -vv"
+       ...
+
+### deb
+
+1. edit `/etc/init.d/td-agent`
+2. add `-vv` to DAEMON_ARGS
+3. restart td-agent
+
+       :::text
+       # at /etc/init.d/td-agent
+       ...
+       DAEMON_ARGS="... -vv"
+       ...
+
+### gem
+
+Please add `-vv` to your command line.
+
+    :::text
+    $ fluentd .. -vv
+
+## Dump fluentd internal information
+
+Fluentd uses [sigdump](https://github.com/frsyuki/sigdump) for dumping fluentd internal information to local file, e.g. thread dump, object allocation and etc.
+If you have a problem with fluentd like process hang, please send `SIGCONT` to fluentd parent and child processes.
+
+## High CPU usage issue
+
+If fluentd suddenly hits unexpected high CPU usage problem, there are several reasons:
+
+- a plugin has a race condition or similar bug
+- dependent gems have a bug
+- regular expression with broken data
+- system calls has a bug, e.g. `inotify` with lots of files
+
+In such cases, you can use `perf` tool on recent Linux to investigate the problem. See [Linux perf Examples](http://www.brendangregg.com/perf.html) page.<br />
+If you want to know which call causes the problem, [pid2line.rb](https://gist.github.com/nurse/0619b6af90df140508c2) is useful.
+
+## Check uncaught logs
+
+You sometimes hit unexpected shutdown with non-zero exit status like below.
+
+    :::text
+    2016-01-01 00:00:00 +0800 [info]: starting fluentd-0.12.28
+    2016-01-01 00:00:00 +0800 [info]: reading config file path="/etc/td-agent/td-agent.conf"
+    [...snip...]
+    2016-01-01 00:00:02 +0800 [info]: process finished code=6
+
+If the problem happens inside ruby, e.g. segmentation fault, C extension bug, etc,
+you can't get entire log when fluentd process is daemonized.
+For example, td-agent launches fluentd with `--daemon` option. In td-agent case,
+you can get entire log using following command to simulate `/etc/init.d/td-agent start` without daemonize.
+
+    :::text
+    $ sudo LD_PRELOAD=/opt/td-agent/embedded/lib/libjemalloc.so /usr/sbin/td-agent -c /etc/td-agent/td-agent.conf --user td-agent --group td-agent

--- a/docs/v0.12/trouble-shooting.txt
+++ b/docs/v0.12/trouble-shooting.txt
@@ -8,29 +8,19 @@ If things aren't happening as expected, please first look at your logs. For td-a
 
 You can get more information about the logs if verbose logging is turned on. Please follow the steps below.
 
-### rpm
+### rpm/deb
 
-1. edit `/etc/init.d/td-agent`
-2. add `-vv` to TD_AGENT_ARGS
-3. restart td-agent
-
-       :::text
-       # at /etc/init.d/td-agent
-       ...
-       TD_AGENT_ARGS="... -vv"
-       ...
-
-### deb
-
-1. edit `/etc/init.d/td-agent`
-2. add `-vv` to DAEMON_ARGS
-3. restart td-agent
+1. Open the service setting file for td-agent (see below for its file path).
+2. Add `-vv` to TD_AGENT_OPTIONS.
+3. Restart td-agent.
 
        :::text
-       # at /etc/init.d/td-agent
-       ...
-       DAEMON_ARGS="... -vv"
-       ...
+       # Add the following settings to:
+       # - /etc/sysconfig/td-agent (CentOS/RedHat)
+       # - /etc/default/td-agent (Debian/Ubuntu)
+       TD_AGENT_OPTIONS="-vv"
+
+Note: The environment variable TD_AGENT_OPTIONS has been introduced in td-agent v2.2.1. If you are using an older version of td-agent, you need to edit `/etc/init.d/td-agent` and insert `-vv` options to TD_AGENT_ARGS or DAEMON_ARGS manually.
 
 ### gem
 


### PR DESCRIPTION
### Problem

As reported by #380, the current documentation on enabling the debug flag
is largely obsolete, as the `init.d` script has been reorganized in td-agent v2.2.1.

### Solution

This patch update the manual to use the new variable `TD_AGENT_OPTIONS`.
(with a side note for users who use the older td-agent <2.2.1).

I confirmed the new instruction works on both Ubuntu 16.04 and CentOS 7.4
with the latest td-agent2 (v2.3.6).
