### PR TITLE
docs: Fix the default value of the `flush_at_shutdown` parameter.

### DIFF
--- a/docs/v1.0/buffer-section.txt
+++ b/docs/v1.0/buffer-section.txt
@@ -272,7 +272,7 @@ These parameters below are to configure buffer plugins and its chunks.
 These parameters are to configure how to flush chunks to optimize performance (latency and throughput).
 
 * ``flush_at_shutdown`` [bool]
-  * Default: false (, but true for file buffer plugin)
+  * Default: false for persistent buffers (e.g. buf_file), true for non-persistent buffers (e.g. buf_memory).
   * The value to specify to flush/write all buffer chunks at shutdown, or not
 * ``flush_mode`` [enum: default/lazy/interval/immediate]
   * Default: default (equals to ``lazy`` if ``time`` is specified as chunk key, ``interval`` otherwise)


### PR DESCRIPTION
This patch adresses the issue reported by #280.

### What is this patch?

For now, the documentation says that `flush_at_shutdown` gets
turned on by default for file buffers.

However, as far as I can tell, this is just plain wrong. In fact, for a
persistent buffer like buf_file, the parameter is turned *off* by default
(we can confirm this in plugin/output.rb).

This patch fixes the issue by updating the buffer section manual.