### PR TITLE
Update link text for v1.0

### DIFF
--- a/lib/toc.en.v1.0.rb
+++ b/lib/toc.en.v1.0.rb
@@ -343,7 +343,7 @@ section 'developer', 'Developer' do
   category 'plugin-development', 'Plugin Development' do
     article 'plugin-development', 'Plugin Development'
     article 'plugin-helper-overview', 'Plugin Helper Overview'
-    article 'plugin-update-from-v12', 'Updating plugins from v0.12 to v0.14' # TODO: add article file
+    article 'plugin-update-from-v12', 'Updating plugins from v0.12 to v1.0'
     article 'plugin-test-code', 'Writing Plugin Test Code'
   end
   category 'plugin-apis', 'Plugin API details' do


### PR DESCRIPTION
'Updating plugins from v0.12 to v0.14' ->
'Updating plugins from v0.12 to v1.0'

Because the title of plugin-update-from-v12.txt has been already
updated for v1.0.