### PR TITLE
docs: Fix an ambiguous sentence in the description of `max_retry_wait`.

### DIFF
--- a/docs/v0.12/_buffer_parameters.txt
+++ b/docs/v0.12/_buffer_parameters.txt
@@ -14,7 +14,9 @@ The interval between data flushes. The default is 60s. The suffixes “s” (sec
 If set to true, Fluentd waits for the buffer to flush at shutdown. By default, it is set to true for Memory Buffer and false for File Buffer.
 
 ### retry_wait, max_retry_wait
-The initial and maximum intervals between write retries.  The default values are 1.0 seconds and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `max_retry_wait` is reached.  In the default configuration the last retry waits for approximately 131072 sec, roughly 36 hours.
+The initial and maximum intervals between write retries.  The default values are 1.0 seconds and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `max_retry_wait` is reached.
+
+Since td-agent will retry 17 times before giving up by default (see the `retry_limit` parameter for details), the sleep interval can be up to approximately 131072 seconds (roughly 36 hours) in the default configurations.
 
 ### retry_limit, disable_retry_limit
 The limit on the number of retries before buffered data is discarded, and an

--- a/docs/v0.12/_timesliced_buffer_parameters.txt
+++ b/docs/v0.12/_timesliced_buffer_parameters.txt
@@ -31,7 +31,9 @@ The interval between data flushes. The default is 60s. The suffixes “s” (sec
 If set to true, Fluentd waits for the buffer to flush at shutdown. By default, it is set to true for Memory Buffer and false for File Buffer.
 
 ### retry_wait, max_retry_wait
-The initial and maximum intervals between write retries.  The default values are 1.0 and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `max_retry_wait` is reached.  In the default configuration the last retry waits for approximately 131072 sec, roughly 36 hours.
+The initial and maximum intervals between write retries.  The default values are 1.0 and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `max_retry_wait` is reached.
+
+Since td-agent will retry 17 times before giving up by default (see the `retry_limit` parameter for details), the sleep interval can be up to approximately 131072 seconds (roughly 36 hours) in the default configurations.
 
 ### retry_limit, disable_retry_limit
 The limit on the number of retries before buffered data is discarded, and an

--- a/docs/v0.12/out_webhdfs.txt
+++ b/docs/v0.12/out_webhdfs.txt
@@ -94,7 +94,9 @@ The interval between data flushes. The default is unspecified, and buffer chunks
 The boolean value to specify whether to flush buffer chunks at shutdown time, or not. The default is true. Specify true if you use `memory` buffer type.
 
 ### retry_wait, max_retry_wait
-The initial and maximum intervals between write retries.  The default values are 1.0 and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `max_retry_wait` is reached.  In the default configuration the last retry waits for approximately 131072 sec, roughly 36 hours.
+The initial and maximum intervals between write retries.  The default values are 1.0 and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `max_retry_wait` is reached.
+
+Since td-agent will retry 17 times before giving up by default (see the `retry_limit` parameter for details), the sleep interval can be up to approximately 131072 seconds (roughly 36 hours) in the default configurations.
 
 ### retry_limit, disable_retry_limit
 The limit on the number of retries before buffered data is discarded, and an

--- a/docs/v1.0/out_webhdfs.txt
+++ b/docs/v1.0/out_webhdfs.txt
@@ -103,7 +103,9 @@ The interval between data flushes. The default is unspecified, and buffer chunks
 The boolean value to specify whether to flush buffer chunks at shutdown time, or not. The default is true. Specify true if you use `memory` buffer type.
 
 ### retry_wait, retry_max_interval
-The initial and maximum intervals between write retries.  The default values are 1.0 and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `retry_max_interval` is reached.  In the default configuration the last retry waits for approximately 131072 sec, roughly 36 hours.
+The initial and maximum intervals between write retries.  The default values are 1.0 and unset (no limit).  The interval doubles (with +/-12.5% randomness) every retry until `retry_max_interval` is reached.
+
+Since td-agent will retry 17 times before giving up by default (see the `retry_max_times` parameter for details), the sleep interval can be up to approximately 131072 seconds (roughly 36 hours) in the default configurations.
 
 ### retry_max_times, retry_forever
 The limit on the number of retries before buffered data is discarded, and an


### PR DESCRIPTION
### What is this patch?

For now, the documentation is a bit ambiguous as to where the (seemingly
arbitrary) "131072 sec" limit comes from. Apparently, this is a source of
confusion for plugin users.

This patch fixes this issue by explaining the context behind it in more detail.

### Note

This patch solves the problem reported by #214