### PR TITLE
docs: Clean up the "Email Alerts like Splunk" article

### DIFF
--- a/docs/v1.0/splunk-like-grep-and-alert-email.txt
+++ b/docs/v1.0/splunk-like-grep-and-alert-email.txt
@@ -4,9 +4,9 @@
 
 In this little "how to" article, we will show you how to build a similar system using Fluentd. More specifically, we will create a system that sends an alert email when it detects a 5xx HTTP status code in an Apache access log.
 
-By the way, Splunk happens to be quite expensive. If you're interested in a free alternative, check out our article [here](free-alternative-to-splunk-by-fluentd).
+If you want a more general introduction to use Fluentd as a free alternative to Splunk, see the article ["Free Alternative to Splunk Using Fluentd"](free-alternative-to-splunk-by-fluentd).
 
-## Installing the Needed Plugins
+## Installing the requisites
 
 [Install](/categories/installation) Fluentd if you haven't yet.
 
@@ -24,61 +24,46 @@ Note: If you installed Fluentd using ruby gems, use `gem` command instead of `td
 
 ## Configuration
 
-### Configuration File: Soup to Nuts
+### Full configuration example
 
-Here is an example configuration file. It's a bit long, but each part is well-commented, so don't be afraid.
+Below shows the full configuration example. You can copy the following content and edit it to suit your needs.
 
     :::text
     <source>
-      @type http #This is for testing
-      port 8888
-    </source>
-
-    <source>
       @type tail
-      path /var/log/apache2/access.log #This is the location of your Apache log
+      path /var/log/apache2/access.log  # Set the location of your log file
       <parse>
         @type apache2
       </parse>
       tag apache.access
     </source>
-    
+
     <match apache.access>
       @type grepcounter
-      count_interval 3 #Time window to grep and count the # of events
-      input_key code #We look at the (http status) "code" field
-      regexp ^5\d\d$ #This regexp matches 5xx status codes
-      threshold 1 #The # of events to trigger emitting an output
-      add_tag_prefix error_5xx #The output event's tag will be error_5xx.apache.access
+      count_interval 3  # The time window for counting errors (in secs)
+      input_key code    # The field to apply the regular expression
+      regexp ^5\d\d$    # The regular expression to be applied
+      threshold 1       # The minimum number of erros to trigger an alart
+      add_tag_prefix error_5xx  # Generate tags like "error_5xx.apache.access"
     </match>
     
     <match error_5xx.apache.access>
-      # The event that comes here looks like
-      #{
-      #  "count":1,
-      #  "input_tag":"error_5xx.apache.access",
-      #  "input_tag_last":"access",
-      #  "message":[500]
-      #}
-
-      @type copy #Copying events, one to send to stdout, another for email alerts
-      
+      @type copy
       <store>
-        @type stdout
+        @type stdout  # Print to stdout for debugging
       </store>
-      
       <store>
         @type mail
-        host smtp.gmail.com #This is for Gmail and Google Apps. Any SMTP server should work
-        port 587 #This is the port for smtp.gmail.com
-        user kiyoto@treasure-data.com #I work here! Use YOUR EMAIL.
-        password XXXXXX #I can't tell you this! Use YOUR PASSWORD!
-        enable_starttls_auto true
-        from YOUR_SENDER_EMAIL_HERE
-        to YOUR_RECIPIENT_EMAIL_HERE
-        subject '[URGENT] APACHE 5XX ERROR'
+        host smtp.gmail.com        # Change this to your SMTP server host
+        port 587                   # Normally 25/587/465 are used for submission
+        user USERNAME              # Use your username to log in
+        password PASSWORD          # Use your login password
+        enable_starttls_auto true  # Use this option to enable STARTTLS
+        from example@gmail.com     # Set the sender address
+        to alart@example.com       # Set the recipient address
+        subject 'HTTP SERVER ERROR'
         message Total 5xx error count: %s\n\nPlease check your Apache webserver ASAP
-        message_out_keys count #The value of 'count' will be substituted into %s above.
+        message_out_keys count     # Use the "count" field to replace "%s" above
       </store>
     </match>
 
@@ -86,19 +71,21 @@ Save your settings to `/etc/td-agent/td-agent.conf` (If you installed Fluentd wi
 
 Please make sure your SMTP configuration is correct before continuing. Otherwise, you will get warnings when you try to run this example.
 
-### What the Configuration File Does
+### How this configuration works
 
-The config above does three things:
+The configuration above consists of three main parts:
 
-1. Sets up Fluentd to tail an Apache log file (located at `/var/log/apache2/access.log`).
-2. Every 3 seconds, it counts the number of events whose "code" field is 5xx. If the number is at least 1 (because of `threshold 1`), emit an event with the tag `error_5xx.apache.access`. All of this is done by `fluent-plugin-grepcounter`.
-3. Sends an email to dev@treasure-data.com (and also outputs to STDOUT for debugging & testing) for each event with the tag `error_5xx.apache.access`.
+  1. The first `<source>` block sets the httpd log file as an event source for the daemon.
 
-We can do all this **without writing a single line of code or paying a dime!**
+  2. The second `<match>` block tells Fluentd to count the number of 5xx responses per time window (3 seconds). If the number exceeds (or is equal to) the given threshold, Fluentd will emit an event with the tag `error_5xx.apache.access`.
 
-## Testing
+  3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and send an email to `alart@example.com` per event.
 
-After saving the configurations, restart the td-agent process:
+In this way, fluentd now works as an email alerting system that monitors the web service for you.
+
+## Test the configuration
+
+After saving the configuration, restart the td-agent process:
 
     :::term
     # for init.d users
@@ -110,14 +97,11 @@ If you installed the standalone version of Fluentd, launch the fluentd process m
 
     $ fluentd -c alart-email.conf
 
-To trigger the alert email, you can either manually append a 5xx error log line to your Apache log or visit (on the same server)
+Then generate some 5xx errors in the web server. If you do not have a convenient way to accomplish this, appending 5xx lines to the log file manually will produce the same result.
 
-    :::text
-    http://localhost:8888/apache/access?json={"code":"500"}
+Now you will receive an alert email titled "HTTP SERVER ERROR".
 
-(This uses the [in_http](in_http) plugin). You should be receiving an alert email with the subject line "[URGENT] APACHE 5XX ERROR" in your inbox right about now!
-
-## What's Next?
+## What's next?
 
 Admittedly, this is a contrived example. In reality, you would set the threshold higher. Also, you might be interested in tracking 4xx pages as well. In addition to Apache logs, Fluentd can handle Nginx logs, syslogs, or any single- or multi-lined logs.
 


### PR DESCRIPTION
This patch is a collection of tiny fixes to make this how-to article
more readable. It includes two categories of improvements:

- GENERAL TONE: Make the general tone of this article more consistent
with other articles. A few assertive statements are dropped (like,
'The competing product X is "quite expensive"').

- CODE EXAMPLE: Trim down the configuration example to make it more
concise. The inline annotations in the example are reformatted for
readability.

This patch should make the article more approachable for users.