### PR TITLE
docs: Fix small nits in the article "Email Alerts like Splunk"

### DIFF
--- a/docs/v0.12/splunk-like-grep-and-alert-email.txt
+++ b/docs/v0.12/splunk-like-grep-and-alert-email.txt
@@ -41,7 +41,7 @@ Below shows the full configuration example. You can copy the following content a
       count_interval 3  # The time window for counting errors (in secs)
       input_key code    # The field to apply the regular expression
       regexp ^5\d\d$    # The regular expression to be applied
-      threshold 1       # The minimum number of erros to trigger an alart
+      threshold 1       # The minimum number of erros to trigger an alert
       add_tag_prefix error_5xx  # Generate tags like "error_5xx.apache.access"
     </match>
     
@@ -50,7 +50,6 @@ Below shows the full configuration example. You can copy the following content a
       <store>
         @type stdout  # Print to stdout for debugging
       </store>
-      
       <store>
         @type mail
         host smtp.gmail.com        # Change this to your SMTP server host
@@ -59,7 +58,7 @@ Below shows the full configuration example. You can copy the following content a
         password PASSWORD          # Use your login password
         enable_starttls_auto true  # Use this option to enable STARTTLS
         from example@gmail.com     # Set the sender address
-        to alart@example.com       # Set the recipient address
+        to alert@example.com       # Set the recipient address
         subject 'HTTP SERVER ERROR'
         message Total 5xx error count: %s\n\nPlease check your Apache webserver ASAP
         message_out_keys count     # Use the "count" field to replace "%s" above
@@ -68,7 +67,10 @@ Below shows the full configuration example. You can copy the following content a
 
 Save your settings to `/etc/td-agent/td-agent.conf` (If you installed Fluentd without td-agent, save the content as 'alert-email.conf' instead).
 
-Please make sure your SMTP configuration is correct before continuing. Otherwise, you will get warnings when you try to run this example.
+Before proceeding, please confirm:
+
+ - The SMTP configuration is correct. You need a working mail server and a proper recipient address to run this example.
+ - The access log file has a proper file permission. You need to make the file readable to the td-agent/Fluentd daemon.
 
 ### How this configuration works
 
@@ -78,7 +80,7 @@ The configuration above consists of three main parts:
 
   2. The second `<match>` block tells Fluentd to count the number of 5xx responses per time window (3 seconds). If the number exceeds (or is equal to) the given threshold, Fluentd will emit an event with the tag `error_5xx.apache.access`.
 
-  3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and send an email to `alart@example.com` per event.
+  3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and send an email to `alert@example.com` per event.
 
 In this way, fluentd now works as an email alerting system that monitors the web service for you.
 
@@ -91,7 +93,7 @@ After saving the configuration, restart the td-agent process:
 
 If you installed the standalone version of Fluentd, launch the fluentd process manually:
 
-    $ fluentd -c alart-email.conf
+    $ fluentd -c alert-email.conf
 
 Then generate some 5xx errors in the web server. If you do not have a convenient way to accomplish this, appending 5xx lines to the log file manually will produce the same result.
 

--- a/docs/v1.0/splunk-like-grep-and-alert-email.txt
+++ b/docs/v1.0/splunk-like-grep-and-alert-email.txt
@@ -43,7 +43,7 @@ Below shows the full configuration example. You can copy the following content a
       count_interval 3  # The time window for counting errors (in secs)
       input_key code    # The field to apply the regular expression
       regexp ^5\d\d$    # The regular expression to be applied
-      threshold 1       # The minimum number of erros to trigger an alart
+      threshold 1       # The minimum number of erros to trigger an alert
       add_tag_prefix error_5xx  # Generate tags like "error_5xx.apache.access"
     </match>
     
@@ -60,7 +60,7 @@ Below shows the full configuration example. You can copy the following content a
         password PASSWORD          # Use your login password
         enable_starttls_auto true  # Use this option to enable STARTTLS
         from example@gmail.com     # Set the sender address
-        to alart@example.com       # Set the recipient address
+        to alert@example.com       # Set the recipient address
         subject 'HTTP SERVER ERROR'
         message Total 5xx error count: %s\n\nPlease check your Apache webserver ASAP
         message_out_keys count     # Use the "count" field to replace "%s" above
@@ -69,7 +69,10 @@ Below shows the full configuration example. You can copy the following content a
 
 Save your settings to `/etc/td-agent/td-agent.conf` (If you installed Fluentd without td-agent, save the content as 'alert-email.conf' instead).
 
-Please make sure your SMTP configuration is correct before continuing. Otherwise, you will get warnings when you try to run this example.
+Before proceeding, please confirm:
+
+ - The SMTP configuration is correct. You need a working mail server and a proper recipient address to run this example.
+ - The access log file has a proper file permission. You need to make the file readable to the td-agent/Fluentd daemon.
 
 ### How this configuration works
 
@@ -79,7 +82,7 @@ The configuration above consists of three main parts:
 
   2. The second `<match>` block tells Fluentd to count the number of 5xx responses per time window (3 seconds). If the number exceeds (or is equal to) the given threshold, Fluentd will emit an event with the tag `error_5xx.apache.access`.
 
-  3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and send an email to `alart@example.com` per event.
+  3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and send an email to `alert@example.com` per event.
 
 In this way, fluentd now works as an email alerting system that monitors the web service for you.
 
@@ -95,7 +98,7 @@ After saving the configuration, restart the td-agent process:
 
 If you installed the standalone version of Fluentd, launch the fluentd process manually:
 
-    $ fluentd -c alart-email.conf
+    $ fluentd -c alert-email.conf
 
 Then generate some 5xx errors in the web server. If you do not have a convenient way to accomplish this, appending 5xx lines to the log file manually will produce the same result.
 


### PR DESCRIPTION
 - User proper spelling: alart -> alert
 - Add cautionary note for file permission issues.