### PR TITLE
doc: Fix an erroneous example code in "Thread Plugin Helper API"

### DIFF
--- a/docs/v1.0/api-plugin-helper-thread.txt
+++ b/docs/v1.0/api-plugin-helper-thread.txt
@@ -12,7 +12,7 @@ Here is the code example with `thread` helper:
         Fluent::Plugin.register_output('example', self)
 
         # 1. load thread helper
-        helpers :threads
+        helpers :thread
 
         # omit configure, shutdown and other plugin API
 


### PR DESCRIPTION
For now, the example code does not work (results in a runtime error)
since it tries to load non-existent plugin 'plugin:threads'.

We can get it to work fine just by fixing it to use 'plugin:thread'.