### PR TITLE
docs: Migrate "filter-modify-apache.txt" to v1.0    

### DIFF
--- a/docs/v0.12/filter-modify-apache.txt
+++ b/docs/v0.12/filter-modify-apache.txt
@@ -1,4 +1,4 @@
-# How To Filter Or Modify Data Inside Fluentd (Apache as an Example)
+# Easy Data Stream Manipulation using Fluentd
 
 In this article, we introduce several common data manipulation challenges faced by our users (such as filtering and modifying data) and explain how to solve each task using one or more Fluentd plugins.
 

--- a/docs/v1.0/filter-modify-apache.txt
+++ b/docs/v1.0/filter-modify-apache.txt
@@ -1,0 +1,77 @@
+# Easy Data Stream Manipulation using Fluentd
+
+Sometimes, you need to transform the data stream in a certain way. For example, you might want to extract a potion of data for error reporting, or need to append additional information to events for later inspection.
+
+This article explains common data-manipulation techniques in details.
+
+## How to Filter Events by Fields
+
+[filter_grep](filter_grep) is a built-in plugin that allows to filter the data stream using regular expressions.
+
+Suppose you are managing a web service, and try to monitor the access logs using Fluentd. In this case, an event in the data stream will look like:
+
+    :::text
+    {
+      "host": "192.168.1.1",
+      "method": "GET",
+      "path": "/index.html",
+      "code": 200,
+      "size": 2344,
+      "referer": null
+    }
+
+Let's filter out all the successful responses with 2xx status codes, so that we can easily inspect if any error has occurred in the service:
+
+    :::text
+    <filter apache.**>
+      @type grep
+      <exclude>
+        key code
+        pattern ^2\d\d$
+      </exclude>
+    </filter>
+
+You can also filter the data using multiple fields. For example, the following example will keep all 5xx server errors, except those coming from the test directory:
+
+    :::text
+    <filter apache.**>
+      @type grep
+      <regexp>
+        key code
+        pattern ^5\d\d$
+      </regexp>
+      <exclude>
+        key path
+        pattern ^/test/
+      </exclude>
+    </filter>
+
+
+## How to Inject Custom Fields into Events
+
+[filter_record_transformer](filter_record_transformer) is a built-in plugin that enables to inject arbitrary data into events.
+
+Suppose you are running a web service on multiple web servers, and you want to record which server handled each request. This can be implemented trivially using this plugin:
+
+    :::text
+    <filter apache.**>
+      @type record_transformer
+      <record>
+        server "${hostname}"
+      </record>
+    </filter>
+
+This will produce an event like below:
+
+    :::text
+    {
+      "host": "192.168.1.1",
+      "method": "GET",
+      "path": "/index.html",
+      "code": 200,
+      "size": 2344,
+      "referer": null,
+      "server": "app1"
+    }
+
+Note that `${hostname}` is a pre-defined variable supplied by the plugin. You can also define a custom variable, or even evaluate arbitrary ruby expressions. For details, please read [the manual page of this plugin](filter_record_transformer).

--- a/lib/toc.en.v0.12.rb
+++ b/lib/toc.en.v0.12.rb
@@ -38,7 +38,6 @@ section 'usecases', 'Use Cases' do
   end
   category 'log-management-and-search', 'Log Management & Search' do
     article 'free-alternative-to-splunk-by-fluentd', 'Free Alternative to Splunk by Fluentd + Elasticsearch', ['Splunk', 'Free Alternative']
-    article 'filter-modify-apache', 'Filter and Modify Data (Apache example)'
     article 'splunk-like-grep-and-alert-email', 'Email Alerts like Splunk', ['Splunk', 'Alerting']
   end
   category 'data-analytics', 'Data Analytics' do
@@ -52,6 +51,7 @@ section 'usecases', 'Use Cases' do
     article 'collect-glusterfs-logs', 'Collecting GlusterFS Logs', ['GlusterFS']
   end
   category 'stream-processing', 'Stream Processing' do
+    article 'filter-modify-apache', 'Easy Data Stream Manipulation using Fluentd'
     article 'kinesis-stream', 'Stream Data Collection to Kinesis Stream', ['kinesis', 'amazon kinesis', 'aws kinesis']
     article 'cep-norikra', 'Fluentd and Norikra: Complex Event Processing', ['cep-norikra']
   end

--- a/lib/toc.en.v1.0.rb
+++ b/lib/toc.en.v1.0.rb
@@ -38,7 +38,6 @@ section 'usecases', 'Use Cases' do
   end
   category 'log-management-and-search', 'Log Management & Search' do
     article 'free-alternative-to-splunk-by-fluentd', 'Free Alternative to Splunk by Fluentd + Elasticsearch', ['Splunk', 'Free Alternative']
-#     article 'filter-modify-apache', 'Filter and Modify Data (Apache example)'
     article 'splunk-like-grep-and-alert-email', 'Email Alerts like Splunk', ['Splunk', 'Alerting']
   end
   category 'data-analytics', 'Data Analytics' do
@@ -52,6 +51,7 @@ section 'usecases', 'Use Cases' do
 #     article 'collect-glusterfs-logs', 'Collecting GlusterFS Logs', ['GlusterFS']
   end
   category 'stream-processing', 'Stream Processing' do
+    article 'filter-modify-apache', 'Easy Data Stream Manipulation using Fluentd'
     article 'kinesis-stream', 'Stream Data Collection to Kinesis Stream', ['kinesis', 'amazon kinesis', 'aws kinesis']
     article 'cep-norikra', 'Fluentd and Norikra: Complex Event Processing', ['cep-norikra']
   end


### PR DESCRIPTION
This patch savages the old article on how we can use filters to
transform event streams. In order to get it work with Fluentd v1.0,
the texts (including the code examples) are thoroughly rewritten.

Although most of the content is already covered by the plugin manuals,
I think a good number of users will still find this article helpful.

Note: For the context behind this pull request, see #413.
