### PR TITLE
lib: Clean up the categorization of articles in "Use Cases".

### DIFF
--- a/lib/toc.en.v0.12.rb
+++ b/lib/toc.en.v0.12.rb
@@ -36,17 +36,17 @@ section 'usecases', 'Use Cases' do
     article 'nodejs', 'Centralize Logs from Node.js Applications'
     article 'scala',   'Centralize Logs from Scala Applications'
   end
-  category 'log-management-and-search', 'Log Management & Search' do
+  category 'monitoring-service-logs', 'Monitoring Service Logs' do
     article 'free-alternative-to-splunk-by-fluentd', 'Free Alternative to Splunk by Fluentd + Elasticsearch', ['Splunk', 'Free Alternative']
     article 'splunk-like-grep-and-alert-email', 'Email Alerts like Splunk', ['Splunk', 'Alerting']
   end
   category 'data-analytics', 'Data Analytics' do
     article 'http-to-td', 'Data Analytics with Treasure Data', ['Treasure Data', 'Hadoop', 'Hive']
     article 'http-to-hdfs', 'Data Collection to Hadoop (HDFS)', ['Hadoop', 'HDFS']
-    article 'apache-to-mongodb', 'Store Apache Logs into MongoDB', ['MongoDB']
   end
-  category 'data-archiving', 'Data Archiving' do
+  category 'data-archiving', 'Connecting to Data Storages' do
     article 'apache-to-s3', 'Store Apache Logs into Amazon S3', ['Amazon S3']
+    article 'apache-to-mongodb', 'Store Apache Logs into MongoDB', ['MongoDB']
     article 'apache-to-riak', 'Store Apache Logs into Riak', ['Riak']
     article 'collect-glusterfs-logs', 'Collecting GlusterFS Logs', ['GlusterFS']
   end

--- a/lib/toc.en.v1.0.rb
+++ b/lib/toc.en.v1.0.rb
@@ -36,18 +36,18 @@ section 'usecases', 'Use Cases' do
     article 'nodejs', 'Centralize Logs from Node.js Applications'
     article 'scala',   'Centralize Logs from Scala Applications'
   end
-  category 'log-management-and-search', 'Log Management & Search' do
+  category 'monitoring-service-logs', 'Monitoring Service Logs' do
     article 'free-alternative-to-splunk-by-fluentd', 'Free Alternative to Splunk by Fluentd + Elasticsearch', ['Splunk', 'Free Alternative']
     article 'splunk-like-grep-and-alert-email', 'Email Alerts like Splunk', ['Splunk', 'Alerting']
   end
   category 'data-analytics', 'Data Analytics' do
     article 'http-to-td', 'Data Analytics with Treasure Data', ['Treasure Data', 'Hadoop', 'Hive']
     article 'http-to-hdfs', 'Data Collection to Hadoop (HDFS)', ['Hadoop', 'HDFS']
-    article 'apache-to-mongodb', 'Store Apache Logs into MongoDB', ['MongoDB']
   end
-  category 'data-archiving', 'Data Archiving' do
+  category 'data-archiving', 'Connecting to Data Storages' do
     article 'apache-to-s3', 'Store Apache Logs into Amazon S3', ['Amazon S3']
     article 'apache-to-minio', 'Store Apache Logs into Minio', ['Minio']
+    article 'apache-to-mongodb', 'Store Apache Logs into MongoDB', ['MongoDB']
 #     article 'apache-to-riak', 'Store Apache Logs into Riak', ['Riak']
 #     article 'collect-glusterfs-logs', 'Collecting GlusterFS Logs', ['GlusterFS']
   end


### PR DESCRIPTION
This small patch is my attempt to improve the categorization to give
the better perspective to newer readers:

  1. Use more descriptable titles to categories
  2. Reclassify articles to group related ones together

For the context of this patch, please see the issue #413.