### PR TITLE
docs: Be consistent in numbering instruction steps.

### DIFF
--- a/docs/v1.0/install-by-deb.txt
+++ b/docs/v1.0/install-by-deb.txt
@@ -8,7 +8,7 @@ INCLUDE: _what_is_td_agent
 
 Please follow the [Preinstallation Guide](before-install) to configure your OS properly. This will prevent many unnecessary problems.
 
-## Step 1 : Install from Apt Repository
+## Step 1: Install from Apt Repository
 
 For Ubuntu, we currently support "Ubuntu 16.04 LTS / Xenial 64bit", "Ubuntu 14.04 LTS / Trusty 64bit".
 
@@ -26,7 +26,7 @@ For Trusty,
 
 It's HIGHLY recommended that you set up <b>ntpd</b> on the node to prevent invalid timestamps in your logs. Please check the [Preinstallation Guide](before-install).
 
-## Step2: Launch Daemon
+## Step 2: Launch Daemon
 
 ### systemd
 
@@ -67,7 +67,7 @@ The following commands are supported:
 
 Please make sure **your configuration file** is located at `/etc/td-agent/td-agent.conf`.
 
-## Step3: Post Sample Logs via HTTP
+## Step 3: Post Sample Logs via HTTP
 
 By default, `/etc/td-agent/td-agent.conf` is configured to take logs from HTTP and route them to stdout (`/var/log/td-agent/td-agent.log`). You can post sample log records using the curl command.
 

--- a/docs/v1.0/install-by-gem.txt
+++ b/docs/v1.0/install-by-gem.txt
@@ -2,23 +2,23 @@
 
 This article explains how to install Fluentd using Ruby gem.
 
-## Step0: Before Installation
+## Step 0: Before Installation
 
 Please follow the [Preinstallation Guide](before-install) to configure your OS properly. This will prevent many unnecessary problems.
 
-## Step1: Install Ruby interpreter
+## Step 1: Install Ruby interpreter
 
 Please install Ruby >= 2.1 on your local environment.
 In addition, install ruby-dev package via package manager to build native extension gems.
 
-## Step2: Install Fluentd gem
+## Step 2: Install Fluentd gem
 
 Fetch and install the `fluentd` Ruby gem using the `gem` command. The official ruby gem page is [here](https://rubygems.org/gems/fluentd).
 
     :::term
     $ gem install fluentd --no-ri --no-rdoc
 
-## Step3: Run
+## Step 3: Run
 
 Run the following commands to confirm that Fluentd was installed successfully:
 

--- a/docs/v1.0/install-by-msi.txt
+++ b/docs/v1.0/install-by-msi.txt
@@ -14,13 +14,13 @@ For Windows, we're using the OS native .msi Installer to distribute td-agent.
 
 NOTE: msi package now uses Ruby 2.3 due to windows related gem issues. Ruby will be updated to 2.4 after fixed issues.
 
-## Step1: Install td-agent
+## Step 1: Install td-agent
 
 Please download the `.msi` file from here, and install the software.
 
 - [Download](https://td-agent-package-browser.herokuapp.com/3/windows)
 
-## Step2: Run td-agent from Command Prompt
+## Step 2: Run td-agent from Command Prompt
 
 First, please prepare your config file located at `C:/opt/td-agent/etc/td-agent/td-agent.conf`. The config below is the simplest example to output any incoming records to td-agent's log file.
 
@@ -52,7 +52,7 @@ It's working properly if td-agent process outputs the message `test.event: {"k",
  <img src="/images/td-agent-windows-prompt.png" />
 </a>
 
-## Step3: Register td-agent to Windows service
+## Step 3: Register td-agent to Windows service
 
 Next, let's register td-agent to Windows service to permanently run as a server process. Please execute `Td-agent Command Prompt` again but with administrative privilege, and type the two commands below.
 
@@ -60,7 +60,7 @@ Next, let's register td-agent to Windows service to permanently run as a server 
     > fluentd --reg-winsvc i
     > fluentd --reg-winsvc-fluentdopt '-c C:/opt/td-agent/etc/td-agent/td-agent.conf -o C:/opt/td-agent/td-agent.log'
 
-## Step4: Run td-agent as Windows service
+## Step 4: Run td-agent as Windows service
 
 Please guide yourself to `Control Panel -> System and Security -> Administrative Tools -> Services`, and you'll see `Fluentd Windows Service` is listed.
 
@@ -68,7 +68,7 @@ Please double click `Fluentd Window Service`, and click `Start` button. Then the
 
 The log file will be located at `C:/opt/td-agent/td-agent.log` as we specified in Step 3.
 
-## Step5: Install Plugins
+## Step 5: Install Plugins
 
 Open `Td-agent Command Prompt` and use `fluent-gem` command.
 

--- a/docs/v1.0/install-by-rpm.txt
+++ b/docs/v1.0/install-by-rpm.txt
@@ -29,7 +29,7 @@ Recent two versions 64bit are supported. This means if latest version is `2017.0
     # Amazon Linux 2
     $ curl -L https://toolbelt.treasuredata.com/sh/install-amazon2-td-agent3.sh | sh
 
-## Step2: Launch Daemon
+## Step 2: Launch Daemon
 
 td-agent provides 2 scripts:
 
@@ -73,7 +73,7 @@ The following commands are supported:
 
 Please make sure **your configuration file** is located at `/etc/td-agent/td-agent.conf`.
 
-## Step3: Post Sample Logs via HTTP
+## Step 3: Post Sample Logs via HTTP
 
 By default, `/etc/td-agent/td-agent.conf` is configured to take logs from HTTP and route them to stdout (`/var/log/td-agent/td-agent.log`). You can post sample log records using the curl command.
 

--- a/docs/v1.0/quickstart.txt
+++ b/docs/v1.0/quickstart.txt
@@ -10,7 +10,7 @@ Fluentd treats logs as JSON, a popular machine-readable format. It is written pr
 
 Fluentd's scalability has been proven in the field: its largest user currently collects logs from **50,000+ servers**.
 
-## Step1: Installing Fluentd
+## Step 1: Installing Fluentd
 
 Please follow the installation/quickstart guides below that matches your environment.
 
@@ -20,7 +20,7 @@ Please follow the installation/quickstart guides below that matches your environ
 * [Install Fluentd by Ruby Gem](install-by-gem)
 * [Install Fluentd from source](install-from-source)
 
-## Step2: Use Cases
+## Step 2: Use Cases
 
 The articles shown below cover the typical use cases of Fluentd. Please refer to the article(s) that suits your needs.
 
@@ -38,7 +38,7 @@ The articles shown below cover the typical use cases of Fluentd. Please refer to
   * Happy Users :)
     * [Users](users)
 
-## Step3: Learn More
+## Step 3: Learn More
 
 The articles shown below will provide detailed information for you to learn more about Fluentd.
 


### PR DESCRIPTION
For now, we mix several notations to denote instruction steps, even
in the same article. For example, in the "Install-by-deb" article,
we see something like below:

    [Table of Contents]
    
    Step 0: Before Installation
    Step 1 : Install from Apt Repository
    Step2: Launch Daemon

See? This seems kinda ugly, and we certainly would better be more consistent.