### PR TITLE
docs: Fix formatting of the article "Buffer Plugin Overview"

### DIFF
--- a/docs/v0.12/buffer-plugin-overview.txt
+++ b/docs/v0.12/buffer-plugin-overview.txt
@@ -67,17 +67,17 @@ The suffixes "k" (KB), "m" (MB), and "g" (GB) can be used for `buffer_chunk_limi
 
 Control the buffer behaviour when the queue becomes full. 3 modes are supported:
 
-- exception
+**1. exception**
 
 This is default mode. This mode raises `BufferQueueLimitError` exception to input plugin. How handle `BufferQueueLimitError` depends on input plugins, e.g. tail input stops reading new lines, forward input returns an error to forward output. This action fits for streaming manner.
 
-- block
+**2. block**
 
 This mode stops input plugin thread until buffer full is resolved. This action is good for batch-like use-case.
 
 We don't recommend to use `block` action to avoid `BufferQueueLimitError`. Please consider improving destination setting to resolve `BufferQueueLimitError` or use `@ERROR` label for routing overflowed events to another backup destination(or `secondary` with lower `retry_limit`). If you hit `BufferQueueLimitError` frequently, it means your destination capacity is insufficient for your traffic.
 
-- drop_oldest_chunk
+**3. drop_oldest_chunk**
 
 This mode drops oldest chunks. This mode is useful for monitoring system destinations. For monitoring, newer events are important than older.
 
@@ -87,8 +87,9 @@ Time Sliced Plugin is a type of Buffer Plugin, so, it has the same basic buffer 
 
 In addition, each chunk is keyed by time and flushed when that chunk's timestamp has passed. This is different from This immediately raises a couple of questions.
 
-1. How do we specify the granularity of time chunks? This is done through the `time_slice_format` option, which is set to "%Y%m%d" (daily) by default. If you want your chunks to be hourly, "%Y%m%d%H" will do the job.
-2. What if new logs come after the time corresponding the current chunk? For example, what happens to an event, timestamped at 2013-01-01 02:59:45 UTC, comes in at 2013-01-01 03:00:15 UTC? Would it make into the 2013-01-01 02:00:00-02:59:59 chunk?
+ 1. How do we specify the granularity of time chunks? This is done through the `time_slice_format` option, which is set to "%Y%m%d" (daily) by default. If you want your chunks to be hourly, "%Y%m%d%H" will do the job.
+
+ 2. What if new logs come after the time corresponding the current chunk? For example, what happens to an event, timestamped at 2013-01-01 02:59:45 UTC, comes in at 2013-01-01 03:00:15 UTC? Would it make into the 2013-01-01 02:00:00-02:59:59 chunk?
   
   This issue is addressed by setting the `time_slice_wait` parameter. `time_slice_wait` sets, in seconds, how long fluentd waits to accept "late" events into the chunk *past the max time corresponding to that chunk*. The default value is 600, which means it waits for 10 minutes before moving on. So, in the current example, as long as the events come in before 2013-01-01 03:10:00, it will make it in to the 2013-01-01 02:00:00-02:59:59 chunk.
 
@@ -96,16 +97,20 @@ In addition, each chunk is keyed by time and flushed when that chunk's timestamp
 
 Here is the diagram shows the relation between buffers and parameters.
 
-<a href="/images/buffer-internal-and-parameters.png"><img src="/images/buffer-internal-and-parameters.png"/></a>
+<div>
+  <a href="/images/buffer-internal-and-parameters.png">
+    <img style='width: 100%;' src="/images/buffer-internal-and-parameters.png"/>
+  </a>
+</div>
 
 ## Secondary output
 
 The backup destination that is used when retry count exceeds `retry_limit`. Currently, primary plugin type or `file` plugin works.
 
+    ::text
     <match pattern>
       @type forward
       ...
-
       <secondary>
         @type file # or forward
         path /var/log/fluent/forward-failed


### PR DESCRIPTION
This is a collection of small fixes to the buffer-overview article.
It includes three categories of improvements:

 1. Enlarge the image to make the diagram easier to view.
 2. Avoid abusing bullet points for denoting sections.
 3. Add a missing language identifier to a code block.

This commit is basically a preparation for the subsequent set of patches.