### PR TITLE
docs: Remove dead link to the old multi-process tuning documentation.

### DIFF
--- a/docs/v1.0/performance-tuning-single-process.txt
+++ b/docs/v1.0/performance-tuning-single-process.txt
@@ -2,7 +2,7 @@
 
 This article describes how to optimize Fluentd's performance within single process. If your traffic is up to 5,000 messages/sec, the following techniques should be enough.
 
-With more traffic, Fluentd tends to be more CPU bound. In such case, please also visit [Performance Tuning (Multi-Process)](performance-tuning-multi-process) to utilize multiple CPU cores.
+With more traffic, Fluentd tends to be more CPU bound. In such case, please consider using ["multi-worker" feature](performance-tuning-single-process#multi-workers).
 
 ## Check your OS configuration
 
@@ -84,5 +84,7 @@ The CPU is often the bottleneck for Fluentd instances that handle billions of in
     <system>
       workers 8
     </system>
+
+For the details of this feature, please read [this release note](https://www.fluentd.org/blog/fluentd-v0.14.15-has-been-released).
 
 * [multi workers](system-config#workers)


### PR DESCRIPTION
### What is this patch?

This patch removes an obsolete link to the article on "Performance
Tuning (Multi-Process)".

Note that the content of this article has been largely deprecated
since the arrival of the new (built-in) multi-processing feature,
and, in fact, this article has never been ported to v1.0.

### Note

This patch is the quick fix for the issue #428.