### PR TITLE
docs: Fix the default value of `enable_watch_timer` to true

### DIFF
--- a/docs/v1.0/in_tail.txt
+++ b/docs/v1.0/in_tail.txt
@@ -227,7 +227,7 @@ The rotate_wait parameter accepts a single integer representing the number of se
 
 | type | default | version |
 |:----:|:-------:|:-------:|
-| bool | false   | 0.14.0  |
+| bool | true    | 0.14.0  |
 
 Enable the additional watch timer.  Setting this parameter to `false` will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with inotify support.  The default is `true` which results in an additional 1 second timer being used.
 


### PR DESCRIPTION
A user suggested that the default value of `enable_watch_timer`
might be misdescrived. As it turns out, it was wrong indeed.

See the line 80 of lib/fluent/plugin/in_tail.rb at Fluentd v1.10:

    config_param :enable_watch_timer, :bool, default: true
    desc 'Enable the stat watcher based on inotify.'

This patch fixes the issue reported by #435.