### PR TITLE
views: Fix a broken link to fluentd.org

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -58,7 +58,7 @@
 
   <div id="wrapper">
     <header id="header">
-      <span class="logo"><a href="https://fluentd.org/">Fluentd</a></span>
+      <span class="logo"><a href="https://www.fluentd.org/">Fluentd</a></span>
       <div class="top-holder">
         <ul>
           <li><a href="https://www.fluentd.org/architecture">What is Fluentd?</a></li>


### PR DESCRIPTION
### Overview

For now, accessing to "https://fluentd.org" results in a connection timeout.
This patch is a quick fix to update the URL to "https://www.fluentd.org".

### Note

This patch fixes the issue #443 and #442.