### PR TITLE
app: Adjust the CSS settings of the common header.

### DIFF
--- a/app/css/header.css
+++ b/app/css/header.css
@@ -21,7 +21,8 @@
 	text-indent:-9999px;
 	overflow:hidden;
 	background:url(../logo/Fluentd_horizontal_banner.png) no-repeat;
-	width:169px;
+	width:170px;
+	margin-left: 15px;
 	height:60px;
 }
 


### PR DESCRIPTION
### What's this patch?

I've noticed that the header area of the documentation site:

- has a truncated logo image. This is the consequence of having a
  display frame (169x70) that is smaller than the image itself (170x70).
- is aligned a bit poorly, due to lacking margin settings.

This patch tries to fix these issues by adjusting the style sheet.

### Screenshot

*Before*

![2018-02-07-155644_375x191_scrot](https://user-images.githubusercontent.com/8974561/35902702-8ff483ec-0c1f-11e8-9b5f-6831e617cc7f.png)

*After*

![2018-02-07-155631_374x196_scrot](https://user-images.githubusercontent.com/8974561/35902712-9439f158-0c1f-11e8-9cf0-5ab5a36397f4.png)
