### PR TITLE
docs: Fix typos in the "Monitoring by Prometheus" article.

### DIFF
--- a/docs/v0.12/monitoring-prometheus.txt
+++ b/docs/v0.12/monitoring-prometheus.txt
@@ -1,6 +1,6 @@
 # Monitoring Fluentd (Prometheus)
 
-Thsi article describes how to monitor Fluentd via [Prometheus](https://prometheus.io/).
+This article describes how to monitor Fluentd via [Prometheus](https://prometheus.io/).
 
 Since both Prometheus and Fluentd are under [CNCF (Cloud Native Computing Foundation)](https://www.cncf.io/), Fluentd project is recommending to use Prometheus by default to monitor Fluentd.
 
@@ -21,7 +21,7 @@ To expose the Fluentd metrics to Prometheus, we need to configure 3 parts:
 
 ### Step 1: Counting Incoming Records by Prometheus Filter Plugin
 
-First, please add the `<filter>` section like below, to count the incoming records per tag. With this configuraiton, `prometheus` filter starts adding the internal counter as the record comes in.
+First, please add the `<filter>` section like below, to count the incoming records per tag. With this configuration, `prometheus` filter starts adding the internal counter as the record comes in.
 
     # source
     <source>
@@ -46,7 +46,7 @@ First, please add the `<filter>` section like below, to count the incoming recor
 
 ### Step 2: Counting Outgoing Records by Prometheus Output Plugin
 
-Second, please use `copy` plugin with `prometheus` output plugin, to count the outgoing records per tag. With this configuraiton, `prometheus` output starts adding the internal counter as the record goes out.
+Second, please use `copy` plugin with `prometheus` output plugin, to count the outgoing records per tag. With this configuration, `prometheus` output starts adding the internal counter as the record goes out.
 
     # count number of outgoing records per tag
     <match company.*>
@@ -74,7 +74,7 @@ Second, please use `copy` plugin with `prometheus` output plugin, to count the o
       </store>
     </match>
 
-### Step 3: Expose Metrics by Prometheus Input Plugion via HTTP
+### Step 3: Expose Metrics by Prometheus Input Plugin via HTTP
 
 Finally, please use `prometheus` input plugin to expose internal counter information via HTTP.
 


### PR DESCRIPTION
While merging #430, I found several typos exist in this article.

So I've applied a spell checker to this article and squeezed out
all of the misspellings found.