### PR TITLE
docs: Fix the Prometheus article to support td-agent systems.

### DIFF
--- a/docs/v0.12/monitoring-prometheus.txt
+++ b/docs/v0.12/monitoring-prometheus.txt
@@ -11,6 +11,11 @@ First of all, please install `fluent-plugin-prometheus` gem.
     :::term
     $ fluent-gem install fluent-plugin-prometheus --version=0.4.0
 
+If you are using td-agent, use `td-agent-gem` for installation.
+
+    :::term
+    $ sudo td-agent-gem install fluent-plugin-prometheus --version=0.4.0
+
 ## Example Fluentd Configuration
 
 To expose the Fluentd metrics to Prometheus, we need to configure 3 parts:
@@ -98,7 +103,10 @@ Finally, please use `prometheus` input plugin to expose internal counter informa
 After you have done 3 changes, please restart fluentd.
 
     :::term
+    # For stand-alone Fluentd installations
     $ fluentd -c fluentd.conf
+    # For td-agent users
+    $ sudo /etc/init.d/td-agent restart
 
 Let's send some records.
 


### PR DESCRIPTION
### What is this patch?

This trivial patch makes the article compatible with td-agent.

### Background

Presumably, there are many users who does not even realise `fluentd`
executable has been installed in their system (this is not so uncommon
since, in the first place, td-agent is supposed to abstract it away).

This patch should be helpful to these users.