### PR TITLE
docs: Explain how to set up TLS/SSL encryption in out_forward.

### DIFF
--- a/docs/v1.0/in_forward.txt
+++ b/docs/v1.0/in_forward.txt
@@ -287,13 +287,13 @@ Then add the following settings to `td-agent.conf`, and then restart the service
       @type stdout
     </match>
 
-Now you can test the settings with the following command:
+To test your encryption settings, execute the following command in your terminal. If the encryption is working properly, you should see a line containing `{"foo":"bar"}` in the log file:
 
     :::term
     $ echo -e '\x93\xa9debug.tls\xceZr\xbc1\x81\xa3foo\xa3bar' | \
       openssl s_client -connect localhost:24224
 
-If you see a line containing `{"foo":"bar"}` in the log file, the encryption has been set up successfully.
+If you can confirm TLS/SSL encryption has been set up correctly, please proceed to [the configuration of the out_forward server](out_forward#how-to-connect-to-a-tls/ssl-enabled-server).
 
 ### Multi-process environment
 

--- a/docs/v1.0/out_forward.txt
+++ b/docs/v1.0/out_forward.txt
@@ -329,6 +329,40 @@ The backup destination that is used when all servers are unavailable.
 
 For more details, see [Secondary Output](output-plugin-overview#secondary-output).
 
+## Tips & Tricks
+
+### How to connect to a TLS/SSL enabled server
+
+If you've [set up TLS/SSL encryption in the receiving server](in_forward#how-to-enable-tls/ssl-encryption), you need to tell the output forwarder to use encryption by setting the `transport` paremter:
+
+```
+<match debug.**>
+  @type forward
+  transport tls
+  <server>
+    host 192.168.1.2
+    port 24224
+  </server>
+</match>
+```
+
+If you're using a self-singed certificate, copy the certificate file to the forwarding server, then add the following settings:
+
+```
+<match debug.**>
+  @type forward
+  transport tls
+  tls_cert_path /path/to/fluentd.crt # Set the path to the certificate file.
+  tls_verify_hostname true           # Set false to ignore cert hostname.
+  <server>
+    host 192.168.1.2
+    port 24224
+  </server>
+</match>
+```
+
+After updating the settings, please confirm that the forwarded data is being received by the destination node properly.
+
 ## Troubleshooting
 
 ### "no nodes are available"


### PR DESCRIPTION
### What's this patch?

In e0253bf, I've updated the `in_forward` manual to include the user
instructions for setting up TLS/SSL encryption.

This is the counter-part patch, which adds an explanation on how to
connect to an encryption-enabled server.

With this patch applied, the task of setting up an end-to-end
encrypted forwarding topology should become (relatively) easier.

### Note

This patch fixes the issue reported by #431.