### PR TITLE
docs: Add a user guide to enable data compression in out_forward.

### DIFF
--- a/docs/v1.0/out_forward.txt
+++ b/docs/v1.0/out_forward.txt
@@ -363,6 +363,25 @@ If you're using a self-singed certificate, copy the certificate file to the forw
 
 After updating the settings, please confirm that the forwarded data is being received by the destination node properly.
 
+### How to enable gzip compression
+
+Since v0.14.7, Fluentd supports transparent data compression. You can use this feature to reduce the transferred payload size.
+
+To enable this feature, set the `compress` option as follows:
+
+```
+<match debug.**>
+  @type forward
+  compress gzip
+  <server>
+    host 192.168.1.2
+    port 24224
+  </server>
+</match>
+```
+
+You don't need any configuration in the receiving server. Data compression is auto-detected and handled transparently by the destination node.
+
 ## Troubleshooting
 
 ### "no nodes are available"


### PR DESCRIPTION
### What's this patch?

This patch adds an instruction to enable the gzip compressed forwarding
introduced in Fluentd v0.14.7.

This feature should be very useful especially for cloud environments
(like AWS) where billing occures based on the transferred data volume.

### Note

This patch address the issue #431.