### PR TITLE
docs: Move a misplaced sentence to the correct place.

### DIFF
--- a/docs/v1.0/out_elasticsearch.txt
+++ b/docs/v1.0/out_elasticsearch.txt
@@ -60,9 +60,9 @@ The nodename and its port pairs.
 
 are accepted.
 
-### user, password, path, scheme, ssl_verify (optional)
-
 If you specify this option, host and port options are ignored.
+
+### user, password, path, scheme, ssl_verify (optional)
 
     :::text
     user fluent


### PR DESCRIPTION
### Overview

The following sentence does not make sense if considered as a description
for "user, password, path, scheme. ssl_verify":

> If you specify this option, host and port options are ignored.

This seems to me like a plain misplacement as suggested by #452.