### PR TITLE
in_http: Apply small fixes to the content texts.

### DIFF
--- a/docs/v1.0/in_http.txt
+++ b/docs/v1.0/in_http.txt
@@ -1,21 +1,21 @@
-# http Input Plugin
+# HTTP Input Plugin
 
-The `in_http` Input plugin enables Fluentd to retrieve records from HTTP POST. The URL path becomes the `tag` of the Fluentd event log and the POSTed body element becomes the record itself.
+The `in_http` Input plugin allows clients to send data in the form of HTTP requests. This is a very handy plugin since you can talk to a Fluentd server in much the same way as to a REST API endpoint.
 
-## Example Configuration
+## Configuration
 
-`in_http` is included in Fluentd's core. No additional installation process is required.
+The following snippet shows an example configuration.
 
     :::text
     <source>
       @type http
-      port 8888
+      port 9880
       bind 0.0.0.0
       body_size_limit 32m
       keepalive_timeout 10s
     </source>
 
-NOTE: Please see the <a href="config-file">Config File</a> article for the basic structure and syntax of the configuration file.
+For the full list of the configurable options, see [the "Parameters" section](#parameters).
 
 ## Basic Usage
 
@@ -23,16 +23,16 @@ Here is a simple example to post a record using `curl`.
 
     :::term
     # Post a record with the tag "app.log"
-    $ curl -X POST -d 'json={"foo":"bar"}' http://localhost:8888/app.log
+    $ curl -X POST -d 'json={"foo":"bar"}' http://localhost:9880/app.log
 
 By default, timestamps are assigned to each record on arrival. You can override the timestamp using the `time` parameter.
 
     :::term
     # Overwrite the timestamp to 2018-02-16 04:40:37.3137116
     $ curl -X POST -d 'json={"foo":"bar"}' \
-      http://localhost:8888/test.tag?time=1518756037.3137116
+      http://localhost:9880/test.tag?time=1518756037.3137116
 
-For more advanced usage, please proceed to ["Tips & Tricks"](#tips-&-tricks).
+For more advanced usage, please read [the "Tips & Tricks" section](#tips-&-tricks).
 
 ## Parameters
 
@@ -109,8 +109,7 @@ If you set `["domain1", "domain2"]` to `cors_allow_origins`, `in_http` returns `
 
 ### format (deprecated)
 
-Deprecated parameter. Use the `<parse>` directive [as explained below](#handle-various-formats-using-parser-plugins).
-
+Deprecated parameter. Use the `<parse>` directive [as explained below](#handle-various-formats-using-parser-plugins) instead.
 
 ## Tips & Tricks
 
@@ -121,7 +120,7 @@ You can post a record in MessagePack format by adding the `msgpack=` prefix.
     :::term
     # Send data in msgpack format
     $ msgpack=`echo -e "\x81\xa3foo\xa3bar"`
-    $ curl -X POST -d "msgpack=$msgpack" http://localhost:8888/app.log
+    $ curl -X POST -d "msgpack=$msgpack" http://localhost:9880/app.log
 
 This reduces the overhead of parsing JSON, hence is relatively faster.
 
@@ -132,18 +131,23 @@ This plugin recognizes the 'Content-Type' header in a POST request. Using this h
     :::term
     # Post a raw JSON data using Content-Type
     $ curl -X POST -d '{"foo":"bar"}' -H 'Content-Type: application/json' \
-      http://localhost:8888/app.log
+      http://localhost:9880/app.log
 
-To use MessagePack format, set the content type to `application/msgpack`.
+To use MessagePack, set the content type to `application/msgpack`.
+
+    :::term
+    $ msgpack=`echo -e "\x81\xa3foo\xa3bar"`
+    $ curl -X POST -d "$msgpack" -H 'Content-Type: application/msgpack' \
+      http://localhost:9880/app.log
 
 ### Handle various formats using parser plugins
 
-You can handle various input formats (other than JSON and MessagePack) by using `<parser>` directive. For example, add the following configuration to the file:
+You can handle various input formats (other than JSON and MessagePack) by using the `<parser>` directive. For example, add the following settings to the configuration file:
 
     :::text
     <source>
       @type http
-      port 8888
+      port 9880
       <parse>
         @type regexp
         expression /^(?<field1>\d+):(?<field2>\w+)$/
@@ -154,25 +158,24 @@ Now you can post custom-format records as below:
 
     :::term
     # This will be parsed into {"field1":"123456","field2":"awesome"}
-    $ curl -X POST -d '123456:awesome' http://localhost:8888/app.log
+    $ curl -X POST -d '123456:awesome' http://localhost:9880/app.log
 
-Other formats (e.g. csv and syslog) are also supported. For the full list of supported plugins, please read [this article](parser-plugin-overview).
+Many other formats (e.g. csv/syslog/nginx) are also supported as well. You can find the full list of supported formats in [this article](parser-plugin-overview).
 
-Note that most parser plugins do not support [the batch mode](#handle-large-data-with-batch-mode). So if you want to use bulk insertion for better performance, please consider using the default JSON/MessagePack format.
+Note that parser plugins do not support [the batch mode](#handle-large-data-with-batch-mode). So if you want to use bulk insertion for handling a large data set, please consider to keep using the default JSON (or MessagePack) format.
 
 ## Enhance Performance
 
 ### Handle large data with batch mode
 
-You can post multiple records in a single request by packing data as a JSON/MessagePack array as below:
+You can post multiple records with a single request by packing data into a JSON/MessagePack array.
 
     :::term
     # Send multiple events as a JSON array
-    $ curl -X POST -d "json=[{"foo":"bar"},{"abc":"xyz"}]" \
-      http://localhost:8888/app.log
+    $ curl -X POST -d "json=[{"foo":"bar"},{"abc":"def"},{"xyz":"123"}]" \
+      http://localhost:9880/app.log
 
-This significantly improves the throughput since we can reduce the number of HTTP requests.
-For example, here is a simple bechmark result on MacBook Pro with ruby 2.3:
+This significantly improves the throughput since it reduces the number of HTTP requests. Here is a simple bechmark result on MacBook Pro with ruby 2.3:
 
 <table>
   <tr>
@@ -189,11 +192,10 @@ Tested configuration and ruby script is [here](https://gist.github.com/repeatedl
 
 If you use this plugin under multi-process environment, port will be shared.
 
-    :::term
+    :::text
     <system>
       workers 3
     </system>
-
     <source>
       @type http
       port 9880
@@ -217,10 +219,10 @@ Here is ruby example:
 curl command example:
 
     # OK
-    curl -X POST -H 'Content-Type: multipart/form-data' -F 'json={"message":"foo+bar"}' http://localhost:8888/test.tag.here
+    curl -X POST -H 'Content-Type: multipart/form-data' -F 'json={"message":"foo+bar"}' http://localhost:9880/app.log
 
     # NG
-    curl -X POST -F 'json={"message":"foo+bar"}' http://localhost:8888/test.tag.here
+    curl -X POST -F 'json={"message":"foo+bar"}' http://localhost:9880/app.log
 
 ## Learn More
 


### PR DESCRIPTION
This patch is a collection of minor fixes to cut the "rough edges"
I noticed while reading the article. Most are editorial fixes.

 - Prefer more consistent word choices (http -> HTTP)
 - Use the consistent port number (8888 vs 9880)
 - Add more working code examples (Sending data in msgpack format)
 - Brush up plugin descriptions.