### PR TITLE
Update logging docs: Fix the end tag for filters in logging for v0.12 and v1.0

### DIFF
--- a/docs/v0.12/logging.txt
+++ b/docs/v0.12/logging.txt
@@ -137,7 +137,7 @@ You can send Fluentd logs to a monitoring service by plugins, e.g. datadog, sent
       <record>
         host "#{Socket.gethostname}"
       </record>
-    </match>
+    </filter>
 
     <match fluent.**>
       @type monitoring_plugin
@@ -158,7 +158,7 @@ Leaf server example:
         host "#{Socket.gethostname}"
         original_tag ${tag}
       </record>
-    </match>
+    </filter>
 
     <match fluent.**>
       @type forward
@@ -179,7 +179,7 @@ Monitoring server example:
       <filter fluent.**>
         @type grep
         regexp1 original_tag fluent.(warn|error|fatal)
-      </match>
+      </filter>
 
       <match fluent.**>
         # your notification setup. This example uses irc plugin

--- a/docs/v1.0/logging.txt
+++ b/docs/v1.0/logging.txt
@@ -150,7 +150,7 @@ You can send Fluentd logs to a monitoring service by plugins, e.g. datadog, sent
         <record>
           host "#{Socket.gethostname}"
         </record>
-      </match>
+      </filter>
 
       <match fluent.*>
         @type monitoring_plugin
@@ -167,13 +167,13 @@ Leaf server example:
     # Add hostname for identifying the server and tag to filter by log level
     <label @FLUENT_LOG>
       # If you want to capture only error events, use 'fluent.error' instead.
-      <match fluent.*>
+      <filter fluent.*>
         @type record_transformer
         <record>
           host "#{Socket.gethostname}"
           original_tag ${tag}
         </record>
-      </match>
+      </filter>
       
       <match fluent.*>
         @type forward
@@ -196,7 +196,7 @@ Monitoring server example:
         key original_tag
         pattern fluent.(warn|error|fatal)
       </regexp>
-    </match>
+    </filter>
 
     <match fluent.*>
       # your notification setup. This example uses irc plugin


### PR DESCRIPTION
## Proposed changes

- Fix the end tag for filters. Use `</filter>` instead of `</match>`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)