### PR TITLE
Update about regexp type and/or directive

### DIFF
--- a/docs/v1.0/api-config-types.txt
+++ b/docs/v1.0/api-config-types.txt
@@ -31,6 +31,34 @@ Configuration Example:
     name John Titor
     passowrd very-secret-password
 
+## :regexp
+
+Define a regexp parameter. Since v1.1.3.
+
+Code Example:
+
+    :::ruby
+    config_param :pattern, :regexp, default: /^key_/
+
+    def configure(conf)
+      super
+
+      log.info(pattern: @pattern)
+    end
+
+    def filter(tag, time, record)
+      new_record = record.select do |k, v|
+        @pattern.match(k)
+      end
+      new_record
+    end
+
+Configuration Example:
+
+    :::text
+    pattern /^name_/
+    pattern ^name_    # Also support pattern without slashes
+
 ## :integer
 
 Define an integer parameter.

--- a/docs/v1.0/filter_grep.txt
+++ b/docs/v1.0/filter_grep.txt
@@ -67,16 +67,18 @@ This parameter supports nested field access via [record_accessor syntax](api-plu
 
 | type   | default            | version  |
 |:------:|:------------------:|:--------:|
-| string | required parameter | 0.14.19  |
+| regexp | required parameter | 1.2.0    |
 
 The regular expression.
+
+The pattern parameter is string type before 1.2.0.
 
 For example, the following filters out events unless the field "price" is a positive integer.
 
     :::text
     <regexp>
       key price
-      pattern [1-9]\d*
+      pattern /[1-9]\d*/
     </regexp>
 
 The grep filter filters out UNLESS all `<regexp>`s are matched. Hence, if you have
@@ -84,11 +86,11 @@ The grep filter filters out UNLESS all `<regexp>`s are matched. Hence, if you ha
     :::text
     <regexp>
       key price
-      pattern [1-9]\d*
+      pattern /[1-9]\d*/
     </regexp>
     <regexp>
       key item_name
-      pattern ^book_
+      pattern /^book_/
     </regexp>
 
 unless the event's "item_name" field starts with "book_" and the "price" field is an integer, it is filtered out.

--- a/docs/v1.0/filter_grep.txt
+++ b/docs/v1.0/filter_grep.txt
@@ -50,6 +50,92 @@ whereas the following examples are filtered out:
 
 [Common Parameters](plugin-common-parameters)
 
+### &lt;and&gt; directive
+
+Specify filtering rule. This directive contains either &lt;regexp&gt; or &lt;exclude&gt; directive.
+This directive has been added since 1.2.0.
+
+    :::text
+    <and>
+      <regexp>
+        key price
+        pattern /[1-9]\d*/
+      </regexp>
+      <regexp>
+        key item_name
+        pattern /^book_/
+      </regexp>
+    </and>
+
+This is same as below:
+
+    :::text
+    <regexp>
+      key price
+      pattern /[1-9]\d*/
+    </regexp>
+    <regexp>
+      key item_name
+      pattern /^book_/
+    </regexp>
+
+We can also use &lt;and&gt; directive with &lt;exclude&gt; directive:
+
+    :::text
+    <and>
+      <exclude>
+        key container_name
+        pattern /^app\d{2}/
+      </exclude>
+      <exclude>
+        key log_level
+        pattern /^(?:debug|trace)$/
+      </exclude>
+    </and>
+
+### &lt;or&gt; directive
+
+Specify filtering rule. This directive contains either &lt;regexp&gt; or &lt;exclude&gt; directive.
+This directive has been added since 1.2.0.
+
+    :::text
+    <or>
+      <exclude>
+        key status_code
+        pattern ^5\d\d$
+      </exclude>
+      <exclude>
+        key url
+        pattern \.css$
+      </exclude>
+    </or>
+
+This is same as below:
+
+    :::text
+    <exclude>
+      key status_code
+      pattern ^5\d\d$
+    </exclude>
+    <exclude>
+      key url
+      pattern \.css$
+    </exclude>
+
+We can also use &lt;or&gt; directive with &lt;regexp&gt; directive:
+
+    :::text
+    <or>
+      <regexp>
+        key container_name
+        pattern /^db\d{2}/
+      </regexp>
+      <regexp>
+        key log_level
+        pattern /^(?:warn|error)$/
+      </regexp>
+    </or>
+
 ### &lt;regexp&gt; directive
 Specify filtering rule. This directive contains two parameters.
 
@@ -140,9 +226,11 @@ This parameter supports nested field access via [record_accessor syntax](api-plu
 
 | type   | default            | version  |
 |:------:|:------------------:|:--------:|
-| string | required parameter | 0.14.19  |
+| regexp | required parameter | 1.2.0    |
 
 The regular expression.
+
+The pattern parameter is string type before 1.2.0.
 
 For example, the following filters out events whose "status_code" field is 5xx.
 

--- a/docs/v1.0/parser_ltsv.txt
+++ b/docs/v1.0/parser_ltsv.txt
@@ -18,10 +18,12 @@ The delimiter character (or string) of TSV values
 
 | type   | default  | version |
 |:------:|:--------:|:-------:|
-| string | nil      | 1.1.0   |
+| regexp | nil      | 1.2.0   |
 
 The delimiter pattern of TSV values.
 This paramter overwrites `delimiter` paramter if specified.
+
+delimiter_pattern is string type before 1.2.0.
 
 ### label_delimiter
 

--- a/docs/v1.0/parser_regexp.txt
+++ b/docs/v1.0/parser_regexp.txt
@@ -16,9 +16,11 @@ See [Parse section configurations](parse-section) for common parameters.
 
 | type   | default            | version |
 |:------:|:------------------:|:-------:|
-| string | required parameter | 0.14.2  |
+| regexp | required parameter | 1.2.0   |
 
 Regular expression for matching logs.
+
+expression is string type before 1.2.0.
 
 ### ignorecase
 
@@ -27,6 +29,9 @@ Regular expression for matching logs.
 | bool | false   | 0.14.2  |
 
 Ignore case in matching.
+Use `i` option with expression.
+
+Deprecated since 1.2.0. Use `expression /pattern/i` instead.
 
 ### multiline
 
@@ -35,6 +40,9 @@ Ignore case in matching.
 | bool | false   | 0.14.2  |
 
 Build regular expression as a multline mode. `.` matches newline. See [Ruby's Regexp document](https://ruby-doc.org/core-2.4.1/Regexp.html#class-Regexp-label-Options)
+Use `m` option with expression.
+
+Deprecated since 1.2.0. Use `expression /pattern/m` instead.
 
 ## Example
 


### PR DESCRIPTION
I assume that Fluentd next version is 1.2.0.
Please merge this PR after release new version of Fluentd that
includes regexp type support and filter_grep's "and/or" directive.