### PR TITLE
docs: Update the version of prometheus to v1

### DIFF
--- a/docs/v1.0/monitoring-prometheus.txt
+++ b/docs/v1.0/monitoring-prometheus.txt
@@ -9,12 +9,12 @@ Since both Prometheus and Fluentd are under [CNCF (Cloud Native Computing Founda
 First of all, please install `fluent-plugin-prometheus` gem.
 
     :::term
-    $ fluent-gem install fluent-plugin-prometheus --version=0.4.0
+    $ fluent-gem install fluent-plugin-prometheus --version='~>1.0.0'
 
 If you are using td-agent, use `td-agent-gem` for installation.
 
     :::term
-    $ sudo td-agent-gem install fluent-plugin-prometheus --version=0.4.0
+    $ sudo td-agent-gem install fluent-plugin-prometheus --version='~>1.0.0'
 
 NOTE: <a href="https://github.com/kzk/fluentd-prometheus-config-example">This GitHub repository</a> contains the fully working configuration for this article.
 


### PR DESCRIPTION
This patch updates the manual to use the newer versions (v1.0.0 or later)
of fluent-plugin-prometheus.

In the process of creating this patch, I've actually confirmed that the
instructions of the article can be followed without any problem using
fluent-plugin-prometheus v1.0.1. So the article does not need to be updated
beyond this trivial fix.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>