### PR TITLE
docs: Fix various typos in articles

### DIFF
--- a/docs/v0.12/monitoring-rest-api.txt
+++ b/docs/v0.12/monitoring-rest-api.txt
@@ -1,6 +1,6 @@
 # Monitoring Fluentd (REST API)
 
-Thsi article describes how to get the internal Fluentd metrics via REST API.
+This article describes how to get the internal Fluentd metrics via REST API.
 
 ## Monitoring Agent
 

--- a/docs/v1.0/format-section.txt
+++ b/docs/v1.0/format-section.txt
@@ -8,9 +8,9 @@ Format section can be in ``<match>`` or ``<filter>`` sections.
 
     <match tag.*>
       @type file
-      # paramters for output plugin
+      # parameters for output plugin
       <format>
-        # format section paramters
+        # format section parameters
       </format>
     </match>
 

--- a/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
+++ b/docs/v1.0/free-alternative-to-splunk-by-fluentd.txt
@@ -139,7 +139,7 @@ For starters, let's access to `http://localhost:5601` and click the "Set up inde
 
 <center><img src="/images/kibana6-screenshot-topmenu.png" width="90%"/></center><br/>
 
-Kibana will starts a wizard that will guide you through configuring data sets to visualize. If you want a quick start, use `logstash-*` as the index pattern, and select `@timestamp` as the time-filter field.
+Kibana will start a wizard that guides you through configuring the data sets to visualize. If you want a quick start, use `logstash-*` as the index pattern, and select `@timestamp` as the time-filter field.
 
 After setting up an index pattern, you can view the system logs as they flow in:
 

--- a/docs/v1.0/monitoring-rest-api.txt
+++ b/docs/v1.0/monitoring-rest-api.txt
@@ -1,6 +1,6 @@
 # Monitoring Fluentd (REST API)
 
-Thsi article describes how to get the internal Fluentd metrics via REST API.
+This article describes how to get the internal Fluentd metrics via REST API.
 
 ## Monitoring Agent
 


### PR DESCRIPTION
This patch is a collection of fixes of typos I found in the manual.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>