### PR TITLE
Fix bad links for out_relabel plugin

### DIFF
--- a/docs/v0.12/routing-examples.txt
+++ b/docs/v0.12/routing-examples.txt
@@ -138,7 +138,7 @@ See also [out_rewrite_tag_filter](out_rewrite_tag_filter) article.
 
 ## Re-route event to other Label
 
-Use [out_relabel](relabel) plugin. `relabel` plugin simply emits events to Label. No tag rewrite.
+Use [out_relabel](out_relabel) plugin. `relabel` plugin simply emits events to Label. No tag rewrite.
 
     <source>
       @type forward

--- a/docs/v1.0/routing-examples.txt
+++ b/docs/v1.0/routing-examples.txt
@@ -138,7 +138,7 @@ See also [out_rewrite_tag_filter](out_rewrite_tag_filter) article.
 
 ## Re-route event to other Label
 
-Use [out_relabel](relabel) plugin. `relabel` plugin simply emits events to Label. No tag rewrite.
+Use [out_relabel](out_relabel) plugin. `relabel` plugin simply emits events to Label. No tag rewrite.
 
     <source>
       @type forward


### PR DESCRIPTION
The [Routing Examples](https://docs.fluentd.org/v1.0/articles/routing-examples#re-route-event-to-other-label) page refers to the `out_relabel` plugin using a link to [articles/relabel](https://docs.fluentd.org/v1.0/articles/relabel), which should be [articles/out_relabel](https://docs.fluentd.org/v1.0/articles/out_relabel).

Both v1.0 and v0.12 have this issue. This pull request fixes them both.