### PR TITLE
Revert "Update in_forward.txt"

### DIFF
--- a/docs/v1.0/in_forward.txt
+++ b/docs/v1.0/in_forward.txt
@@ -277,7 +277,7 @@ Then add the following settings to `td-agent.conf`, and then restart the service
 
     <source>
       @type forward
-      <transport>
+      <transport tls>
         cert_path /etc/td-agent/certs/fluentd.crt
         private_key_path /etc/td-agent/certs/fluentd.key
         private_key_passphrase YOUR_PASSPHRASE


### PR DESCRIPTION
### Problem

The commit 8c33943 fixes `<transport tls>` to `<transport>` in an
assumption that the `tls` part is mistyped.

However, it is NOT a typo. In fact, if we define a transport section
without the argument, Fluentd won't enable TLS encryption. So we
need to revert the changeset done by #479.

### Related Links

See `lib/fluent/plugin_helper/server.rb:72` for details:

https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin_helper/server.rb#L71