### PR TITLE
Add a guide to set up password authentication for in/out_forward

### DIFF
--- a/docs/v1.0/in_forward.txt
+++ b/docs/v1.0/in_forward.txt
@@ -320,6 +320,22 @@ To check if mutual authentication is working properly, issue the following comma
 
 If the connection gets established successfully, your setup is working fine.
 
+### How to Enable Password Authentication
+
+Fluentd is equipped with a password-based authentication mechanism, which allows you to verify the identity of each client using a shared secret key.
+
+To enable this feature, you need to add a `<secrity>` section to your configuration file as below.
+
+    <source>
+      @type forward
+      <security>
+        self_hostname YOUR_SERVER_NAME
+        secret_key PASSWORD
+      </security>
+    </source>
+
+Once you've done the setup, you have to configure your clients accordingly. For example, if you have an `out_forward` instance running on another server, please [configure it following the instruction](out_forward#how-to-enable-password-authentication).
+
 ### Multi-process environment
 
 If you use this plugin under multi-process environment, port will be shared.

--- a/docs/v1.0/out_forward.txt
+++ b/docs/v1.0/out_forward.txt
@@ -333,7 +333,7 @@ For more details, see [Secondary Output](output-plugin-overview#secondary-output
 
 ### How to connect to a TLS/SSL enabled server
 
-If you've [set up TLS/SSL encryption in the receiving server](in_forward#how-to-enable-tls/ssl-encryption), you need to tell the output forwarder to use encryption by setting the `transport` paremter:
+If you've [set up TLS/SSL encryption in the receiving server](in_forward#how-to-enable-tls/ssl-encryption), you need to tell the output forwarder to use encryption by setting the `transport` parameter:
 
 ```
 <match debug.**>
@@ -362,6 +362,24 @@ If you're using a self-singed certificate, copy the certificate file to the forw
 ```
 
 After updating the settings, please confirm that the forwarded data is being received by the destination node properly.
+
+### How to Enable Password Authentication
+
+If you want to connect to [a server that requires password authentication](in_forward#how-to-enable-password-authentication), you need to set your credentials in the configuration file.
+
+    <match debug.**>
+      @type forward
+      <server>
+        host 192.168.1.2
+        port 24224
+      </server>
+      <security>
+        self_hostname HOSTNAME
+        shared_key secret
+      </security>
+    </match>
+
+Note that, as to the option `self_hostname`, you need to set the name of the server on which your `out_forward` instance is running. In the current implementation, it is considered invalid if your `in_forward` and `out_forward` shares the same hostname.
 
 ### How to enable gzip compression
 


### PR DESCRIPTION
This patch adds a step-by-step instruction to enable the challenge-response
authentication mechanism, which was introduced in Fluentd v0.14.5.

For details, see: https://github.com/fluent/fluentd/pull/1136

Since `out_forward` has not supported TLS mutual authentication yet, this is
the only built-in mechanism to prevent rogue clients from connecting.
So this guide should be still somewhat useful.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>