### PR TITLE
out_stdout: Remove an irrelevant note from the documentation.

### DIFF
--- a/docs/v1.0/out_stdout.txt
+++ b/docs/v1.0/out_stdout.txt
@@ -22,9 +22,6 @@ A sample output is as follows:
 where the first part shows the output time, the second part shows the tag,
 and the third part shows the record.
 
-NOTE: The first part shows the <strong>output</strong> time, not the time attribute
-of message event structure as <code>out_stdout</code> does.
-
 ## Supported modes
 
 * Non-Buffered


### PR DESCRIPTION
This patch is based on the suggestion by Eugen Cristea.

See the ticket #505 for details.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>