### PR TITLE
elasitcsearch: Update the documentation for plugin parameters.

### DIFF
--- a/docs/v1.0/out_elasticsearch.txt
+++ b/docs/v1.0/out_elasticsearch.txt
@@ -1,32 +1,33 @@
 # Elasticsearch Output Plugin
 
-The `out_elasticsearch` Output plugin writes records into Elasticsearch. By default, it creates records by bulk write operaion. This means that when you first import records using the plugin, no record is created immediately.
+The `out_elasticsearch` Output plugin writes records into Elasticsearch. By default, it creates records by bulk write operation. This means that when you first import records using the plugin, no record is created immediately.
 
 The record will be created when the `chunk_keys` condition has been met. To change the output frequency, please specify the `time` in chunk_keys and specify `timekey` value in conf.
 
 NOTE: This document doesn't describe all parameters. If you want to know full features, check the Further Reading section.
 
-## Install
+## Installation
 
-`out_elasticsearch` is included in td-agent by default (v3.0.1 or later). Fluentd gem users will have to install the fluent-plugin-elasticsearch gem using the following command.
+Since `out_elasticsearch` has been included in the standard distribution of td-agent since v3.0.1, td-agent users do not need to install it manually.
+
+If you have installed Fluentd without td-agent, please install this plugin using `fluent-gem`.
 
     :::term
     $ fluent-gem install fluent-plugin-elasticsearch
 
 ## Example Configuration
 
-Additional configurations are optional.
+The following is a simple working configuration. This should serve as a good starting point for most users.
 
     :::text
     <match my.logs>
       @type elasticsearch
       host localhost
       port 9200
-      index_name fluentd
-      type_name fluentd
+      logstash_format true
     </match>
 
-NOTE: Please see the <a href="config-file">Config File</a> article for the basic structure and syntax of the configuration file. For &lt;buffer&gt; section, please check <a href="buffer-section">Buffer section cofiguration</a>.
+For more details on each option, read [the section on Parameters](#parameters).
 
 ## Plugin helpers
 
@@ -35,56 +36,68 @@ NOTE: Please see the <a href="config-file">Config File</a> article for the basic
 
 ## Parameters
 
-[Common Parameters](plugin-common-parameters)
-
 ### @type (required)
 
-The value must be `elasticsearch`.
+This option must be always `elasticsearch`.
 
 ### host (optional)
 
-The namenode hostname.
+The hostname of your Elasticsearch node (default: `localhost`).
 
 ### port (optional)
 
-The namenode port number.
+The port number of your Elasticsearch node (default: `9200`).
 
 ### hosts (optional)
 
-The nodename and its port pairs.
+If you want to connect to more than one Elasticsearch nodes, specify this option in the following format:
 
     :::text
     hosts host1:port1,host2:port2,host3:port3
     # or
     hosts https://customhost.com:443/path,https://username:password@host-failover.com:443
 
-are accepted.
+If you use this option, the `host` and `port` options are ignored.
 
-If you specify this option, host and port options are ignored.
+### user, password (optional)
 
-### user, password, path, scheme, ssl_verify (optional)
+The login credentials to connect to the Elasticsearch node (default: `nil`)
 
     :::text
     user fluent
-    password fluentd
-    path /elastic_search/
-    scheme https
+    password mysecret
 
-### logstash_format (optional)
+### scheme (optional)
 
-Defaults to false.
+Specify `https` if your Elasticsearch endpoint supports SSL (default: `http`)
 
-If you specify this option, fluent-plugin-elasticsearch will use `logstash-%Y.%m.%d` style indices.
+### path (optional)
+
+The REST API endpoint of Elasticsearch to post write requests (default: `nil`)
 
 ### index_name (optional)
 
-If you specify this option, fluent-plugin-elasticsearch will use `fluentd` style index.
+The index name to write events to (default: `fluentd`).
+
+This option supports the placeholder syntax of Fluentd plugin API. For example, if you want to partition the index by tags, you can specify as below:
+
+    :::text
+    index_name fluentd.${tag}
+
+Here is a more practical example which partitions the Elasticsearch index by tags and timestamps:
+
+    :::text
+    index_name fluentd.${tag}.%Y%m%d
+
+### logstash_format (optional)
+
+With this option set `true`, Fluentd uses the conventional index name format `logstash-%Y.%m.%d` (default: `false`). This option supersedes the `index_name` option.
 
 INCLUDE: _log_level_params
 
 ## Miscellaneous
 
-You can use `%{}` style placehodlers to escape for URL encoding needed characters.
+You can use `%{}` style placeholders to escape for URL encoding needed characters.
 
     :::text
     user %{demo+}


### PR DESCRIPTION
### What's this patch?

MartinVUALTO points out that configuration parameters are poorly
documented in the manual of `out_elasticsearch` right now.

I basically agree with this observation. So I rewrote the most of
the descriptions in the manual and added more examples for them.

Also I fixed a number of typos found in the article.

### Memo

@cosmo0920 Can you check this update and report back to me if there is
something described wrongly?