### PR TITLE
In_forward: Fix typo in example

### DIFF
--- a/docs/v1.0/in_forward.txt
+++ b/docs/v1.0/in_forward.txt
@@ -330,7 +330,7 @@ To enable this feature, you need to add a `<security>` section to your configura
       @type forward
       <security>
         self_hostname YOUR_SERVER_NAME
-        secret_key PASSWORD
+        shared_key PASSWORD
       </security>
     </source>
 


### PR DESCRIPTION
It's `shared_key`, not `secret_key`.