### PR TITLE
in_monitor_agent: Add a missing documentation for `include_reply`

### DIFF
--- a/docs/v1.0/in_monitor_agent.txt
+++ b/docs/v1.0/in_monitor_agent.txt
@@ -62,9 +62,17 @@ The interval time between event emits. This will be used when `tag` is configure
 
 | type | default | version |
 |:----:|:-------:|:-------:|
-| bool | true   | 0.14.0  |
+| bool | true    | 0.14.0  |
 
-Remove `config` field from the response.
+You can set this option to false to remove `config` field from the response.
+
+### include_retry
+
+| type | default | version |
+|:----:|:-------:|:-------:|
+| bool | true    | 0.14.11 |
+
+You can set this option to false to remove `retry` field from the response.
 
 ## Output Example
 


### PR DESCRIPTION
### What's this patch?

This patch documents the monitor agent option which has not been
described in the manual page properly.

Note that, as opposed to the name, this option is intended to allow
users to _exclude_ the 'retry' bit from the response, so we would be
better to explain our intention clearly here.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>