### PR TITLE
in_monitor_agent: Add a note on how to retrieve data in LTSV format.

### DIFF
--- a/docs/v1.0/in_monitor_agent.txt
+++ b/docs/v1.0/in_monitor_agent.txt
@@ -17,6 +17,10 @@ This configuration launches HTTP server with 24220 port and get metrics like bel
 
     $ curl http://host:24220/api/plugins.json
 
+Also you can fetch the same data in LTSV format:
+
+    $ curl http://host:24220/api/plugins
+
 NOTE: Please see the <a href="config-file">Config File</a> article for the basic structure and syntax of the configuration file.
 
 ## Parameters


### PR DESCRIPTION
in_monitor_agent has an undocumented feature that allows users to
retrieve metrics in LTSV format (instead of JSON).

Since this feature seems to be useful, let's describe this feature
on the manual page.