### PR TITLE
rpc: Add documentation for '/api/processes.flushBuffersAndKillWorkers'

### DIFF
--- a/docs/v1.0/rpc.txt
+++ b/docs/v1.0/rpc.txt
@@ -33,10 +33,14 @@ Replacement of signal's [SIGINT](signals#sigint-or-sigterm). Stop the daemon.
 
 Replacement of signal's [SIGTERM](signals#sigint-or-sigterm). Stop the daemon.
 
+### /api/processes.flushBuffersAndKillWorkers
+
+This is essentially a combination of [SIGUSR1](signals#sigusr1) and [SIGTERM](signals#sigint-or-sigterm). Flush the buffer then stop the daemon.
+
 ### /api/plugins.flushBuffers
 
-Replacement of signal's [SIGUSR1](signals#sigusr1). Flushes buffered messages.
+Replacement of signal's [SIGUSR1](signals#sigusr1). Flush the buffered messages.
 
 ### /api/config.reload
 
-Replacement of signal's [SIGHUP](signals#sighup). reload configuration.
+Replacement of signal's [SIGHUP](signals#sighup). Reload configuration.


### PR DESCRIPTION
This RPC endpoint was added in 8507b3c (roughly two years ago) but not
documented yet. So add the documentation for it.

Also this patch applies a small clean-up on the "RPCs" section, which
should make the manual a little easier to read.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>