### PR TITLE
parser: Use a more concrete example to illustrate basic usage

### DIFF
--- a/docs/v0.12/parser-plugin-overview.txt
+++ b/docs/v0.12/parser-plugin-overview.txt
@@ -11,13 +11,14 @@ Sometimes, the `format` parameter for input plugins (ex: [in_tail](in_tail), [in
 * Write a custom format plugin. [See here for more information](plugin-development#parser-plugins).
 * From any input plugin that supports the "format" field, call the custom plugin by its name. 
 
-Here is an example with in_tail:
+Here is a simple example to read Nginx access logs using `in_tail` and `parser_nginx`:
 
     :::text
     <source>
       @type tail
       path /path/to/input/file
-      format my_custom_parser
+      format nginx
+      keep_time_key true
     </source>
 
 ## List of Built-in Parsers

--- a/docs/v1.0/parser-plugin-overview.txt
+++ b/docs/v1.0/parser-plugin-overview.txt
@@ -11,14 +11,15 @@ Sometimes, the `<parse>` directive for input plugins (ex: [in_tail](in_tail), [i
 * Write a custom format plugin. [See here for more information](plugin-development#parser-plugins).
 * From any input plugin that supports the `<parse>` directive, call the custom plugin by its name. 
 
-Here is an example with in_tail:
+Here is a simple example to read Nginx access logs using `in_tail` and `parser_nginx`:
 
     :::text
     <source>
       @type tail
       path /path/to/input/file
       <parse>
-        @type my_custom_parser
+        @type nginx
+        keep_time_key true
       </parse>
     </source>
 


### PR DESCRIPTION
kriston13 points out that the configuration example in the current
manual page is not very well chosen because it fails to describe how
one can modify the parser behaviour through its options.

This patch fixes the manual to use a more concrete example (in_tail
\+ parser_nginx).

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>