### PR TITLE
Migrate the manual on filter_stdout to version 1.X

### DIFF
--- a/docs/v1.0/filter_stdout.txt
+++ b/docs/v1.0/filter_stdout.txt
@@ -1,7 +1,5 @@
 # stdout Filter Plugin
 
-NOTE: This page is simply copied from LINK(v0.12):[v0.12 documents](/articles/filter_stdout), and will be updated later.
-
 The `filter_stdout` filter plugin prints events to stdout (or logs if launched
 with daemon mode). This filter plugin is useful for debugging purposes.
 
@@ -22,9 +20,6 @@ A sample output is as follows:
 
 where the first part shows the output time, the second part shows the tag,
 and the third part shows the record.
-
-NOTE: The first part shows the <strong>output</strong> time, not the time attribute
-of message event structure as <code>out_stdout</code> does.
 
 ## Plugin helpers
 


### PR DESCRIPTION
We just need to be clear that this document has already upgraded to
v1.X, so that we do not confuse readers.

I also removed the note on timestamps since what it claims does not
seem to be true anymore.