### PR TITLE
output: Clean up the explanations of various buffering modes

### DIFF
--- a/docs/v1.0/api-plugin-output.txt
+++ b/docs/v1.0/api-plugin-output.txt
@@ -89,46 +89,29 @@ The exact set of methods to be implemented is dependent on the design of your pl
 
 ## Modes of Output Plugins
 
-Output plugins has 3 mode for output, and 2 way for formatting buffer chunks (for buffered output). Plugins can implement one of these modes, or also can implement some/all of these modes. Users can choose a mode of these by configuration if 2 or more modes are available. Plugins can make a default (preferred) mode if users don't select mode explicitly.
+Output plugins have three operation modes. Each mode has a set of interfaces to be implemented. Any output plugin must support (at least) one of these three modes.
 
-### Output modes
+### Non-buffered Mode
 
-#### Non-buffered output
+This is the simplest operation mode. The output plugin transfers events to the destination immediately after the reception. It does not use any buffer and never attempts to retry on errors.
 
-Fluentd calls ``#process`` method immediately after input plugins emit events into Fluentd router.
-Output plugins should output these events to destinations, without any errors. Fluentd doesn't retry for failures in this mode.
+For example, the built-in plugin `out_stdout` normally operates in this mode; This plugin just writes each event to stdout and essentially has no state.
 
 This mode is available when ``#process`` method is implemented.
 
-#### Sync buffered output
+### Sync Buffered Mode
 
-Fluentd stores events in buffer chunks, then calls ``#write``.  Users can control how to split chunks and how often to write chunks.
-Output plugins should output these events to destinations, or raise errors if any failure occurs. Fluentd will retry to write chunks for errors.
+In this mode, the output plugin temporally stores events in a buffer and send them later. The exact behaviour of buffering is finely tunable though configuration parameters.
+
+The most notable benefit of this mode is that it enables you to leverage a native retry mechanism. Most temporal errors (like network failures) are transparently handled by Fluentd and you do not need to implement an error-handling mechanism by yourself.
 
 This mode is available when ``#write`` method is implemented.
 
-#### Async buffered output (Delayed Commit)
+### Async Buffered Mode
 
-Fluentd stores events in buffer chunks, then calls ``#try_write``. Users can control how to split chunks and how often to write chunks.
-Output plugins should output these events to destinations, and then call ``#commit_write`` to tell Fluentd core that write operation succeeded (it can be done from another threads). Fluentd will retry to write chunks when any errors are raised from ``#try_write`` or when chunks are not committed until timeout. Timeout seconds can be configured by ``delayed_commit_timeout`` parameter.
+In this mode, the output plugin temporally stores events in a buffer and send them later. The major difference with the synchronous mode is that this mode allows you to defer acknowledgement of transferred records. For example, you can implement the "at-least-once" semantics using this mode. Please read "How To Use Asynchronous Buffered Mode" for details.
 
 This mode is available when ``#try_write`` method is implemented.
-
-### Formatting modes
-
-#### Standard format
-
-Fluentd v1.0 has "standard" format for buffer chunks. If output plugins don't implement ``#format`` method, Fluentd uses this standard format.
-Buffer chunks with this format are iterable by ``chunk.each`` method to extract events from chunk body.
-
-Some tools will be provided with Fluentd core to read/extract buffer chunks formatted by standard format. If your plugin does iterate events from buffer chunks, it's the best to use standard format.
-
-#### Custom format
-
-Fluentd uses custom format if plugins implement ``#format`` method. That method should return a String as representation of an event.
-Fluentd appends it into buffer chunk body.
-
-Custom format is useful when output plugins write data into plain text file on local disks or distributed file systems.
 
 ### How Fluentd Chooses Modes
 
@@ -153,6 +136,25 @@ When plugin does buffering:
 * Else plugin does as implemented
 
 It's an important point that methods to decide modes will be called in ``#start`` methods, which is called after ``#configure``. So plugins can decide the default behavior with configured parameter values by overriding these methods (``#prefer_buffer_processing`` and ``#prefer_delayed_commit``).
+
+## Formatting modes
+
+For a buffering output plugin, you can customize how it serializes events.
+
+### Standard format
+
+Fluentd v1.0 has "standard" format for buffer chunks. If output plugins don't implement ``#format`` method, Fluentd uses this standard format. Buffer chunks with this format are iterable by ``chunk.each`` method to extract events from chunk body.
+
+Some tools will be provided with Fluentd core to read/extract buffer chunks formatted by standard format. If your plugin does iterate events from buffer chunks, it's the best to use standard format.
+
+### Custom format
+
+Fluentd uses custom format if plugins implement ``#format`` method. That method should return a String as representation of an event.
+Fluentd appends it into buffer chunk body.
+
+Custom format is useful when output plugins write data into plain text file on local disks or distributed file systems.
+
+## Development Guide
 
 ### How To Use Asynchronous Buffered Mode and Delayed Commit
 


### PR DESCRIPTION
### What's this patch?

This should give readers a more concise overview on how each buffering
mode work and what is the characteristics of each.

Also this improves the overall structure a bit, by moving the part on
"format mode" into a separate section.

### Links

Read #541 for the underlying motivation of this patch.