### PR TITLE
elasticsearch: Add validate_client_version description

### DIFF
--- a/docs/v1.0/out_elasticsearch.txt
+++ b/docs/v1.0/out_elasticsearch.txt
@@ -139,7 +139,7 @@ For example, td-agent currently bundles the 6.x series of the [elasticsearch-rub
     # For standalone Fluentd users
     $ fluent-gem list elasticsearch
 
-Or, fluent-plugin-elasticsearch v2.11.8 or later, users can inspect version incompatibility with the `validate_client_version` option:
+Or, fluent-plugin-elasticsearch v2.11.7 or later, users can inspect version incompatibility with the `validate_client_version` option:
 
     :::text
     validate_client_version true

--- a/docs/v1.0/out_elasticsearch.txt
+++ b/docs/v1.0/out_elasticsearch.txt
@@ -139,6 +139,17 @@ For example, td-agent currently bundles the 6.x series of the [elasticsearch-rub
     # For standalone Fluentd users
     $ fluent-gem list elasticsearch
 
+Or, fluent-plugin-elasticsearch v2.11.8 or later, users can inspect version incompatibility with the `validate_client_version` option:
+
+    :::text
+    validate_client_version true
+
+If you get the following error message, please consider to install compatibile elasticsearch client gems:
+
+    :::text
+    Detected ES 5 but you use ES client 6.1.0.
+    Please consider to use 5.x series ES client.
+
 For further details of the version compatibility issue, please read [the official manual](https://github.com/elastic/elasticsearch-ruby#compatibility).
 
 ## Further Reading


### PR DESCRIPTION
Follows up https://github.com/fluent/fluentd-docs/pull/545.

This option is useful to investigate version incompatibility between ES
client and ES server.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>