### PR TITLE
in_syslog: Explain how to set up the syslog daemon

### DIFF
--- a/docs/v1.0/in_syslog.txt
+++ b/docs/v1.0/in_syslog.txt
@@ -14,7 +14,11 @@ The `in_syslog` Input plugin enables Fluentd to retrieve records via the syslog 
       tag system
     </source>
 
-NOTE: Please see the <a href="config-file">Config File</a> article for the basic structure and syntax of the configuration file.
+This tells Fluentd to create a socket listening on port 5140. You need to set up your syslog daemon to send messages to the socket. For example, if you're using rsyslogd, add the following lines to `/etc/rsyslog.conf`.
+
+    :::text
+    # Send log messages to Fluentd
+    *.* @127.0.0.1:5140
 
 ### Example Usage
 


### PR DESCRIPTION
To use in_syslog, we normally need to set up our syslog daemon too
(otherwise no one sends data there). I think it's worth adding a
line that explains how to do this.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>