### PR TITLE
out_rewrite_tag_filter: write about the re-emission

### DIFF
--- a/docs/v1.0/out_rewrite_tag_filter.txt
+++ b/docs/v1.0/out_rewrite_tag_filter.txt
@@ -9,8 +9,9 @@ The plugin is configured by defining a list of rules containing conditional
 statements and information on how to rewrite matching tags.
 
 When a message is handled by the plugin, the rules are tested one by one in
-order and if a matching rule is found the message tag will be rewritten
-according to the definition in the rule.
+order. If a matching rule is found, the message tag will be rewritten according
+to the definition in the rule and the message will be emitted again with the
+new tag.
 
 ### Example
 


### PR DESCRIPTION
out_rewrite_tag_filter is not a usual output plugin; It never emit
events to external endpoints, but it re-submit the message to the
event queue for processing again.

The manual page should explain it clearly.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>