### PR TITLE
FAQ: Explain how to use Oj as JSON parser on Alpine Linux

### DIFF
--- a/docs/v1.0/faq.txt
+++ b/docs/v1.0/faq.txt
@@ -77,6 +77,14 @@ There are several approaches to avoid this problem.
   - Use `record_modifier` filter to change the encoding. See [fluent-plugin-record-modifier README](https://github.com/repeatedly/fluent-plugin-record-modifier#char_encoding)
 - Use `yajl` instead of `json` when error happens inside `JSON.parse/JSON.dump`
 
+### Fluentd warns "Oj is not installed, and failing back to Yajl for json parser"
+
+If you are using Alpine Linux, you need to install `ruby-bigdecimal` to use Oj
+as the JSON parser. Please Execute the following command and see if the warning
+still shows up.
+
+    # apk add --update ruby-bigdecimal
+
 ## Plugin Development
 
 ### How do I develop a custom plugin?


### PR DESCRIPTION
This is indeed a "frequently asked" question, popping up several times
on the support forum.

The gotcha is that Alpine Linux has a separate package 'ruby-decimal'
for BigDecimal class, so we need to install the package manually in
order to prevent `require oj` from failing with a LoadError exception.

Related: https://github.com/fluent/fluentd/issues/2136