### PR TITLE
buffer: describe "disable_chunk_backup" in the manual pages

### DIFF
--- a/docs/v1.0/buffer-plugin-overview.txt
+++ b/docs/v1.0/buffer-plugin-overview.txt
@@ -64,6 +64,8 @@ Since v1.2.0, Fluentd can detect these non-recoverable failures. If these kinds 
 
     ${root_dir}/backup/worker${worker_id}/${plugin_id}/{chunk_id}.log
 
+If you don't need to back up chunks, you can enable `disable_chunk_backup` (available since v1.2.6) in the `<buffer>` section.
+
 The following is the current list of exceptions considered "unrecoverable":
 
  Exception                   |  The typical cause of this error

--- a/docs/v1.0/buffer-section.txt
+++ b/docs/v1.0/buffer-section.txt
@@ -365,6 +365,10 @@ These parameters are to configure how to flush chunks to optimize performance (l
 * ``retry_randomize`` [bool]
   * Default: true
   * If true, output plugin will retry after randomized interval not to do burst retries
+* ``disable_chunk_backup`` [bool]
+  * Default: false
+  * Instead of storing unrecoverable chunks in the backup directory, just discard them.
+    This option is new in Fluentd v1.2.6.
 
 With exponential backoff, retry wait interval will be calculated as below:
 


### PR DESCRIPTION
This option is new in Fluentd v1.2.6.

https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v126---20181003

I added this option to "Buffer section configuration" and also added a short
mention to the overview page.