### PR TITLE
elasticsearch: Add time chunk_keys supplementary description for time placeholder

### DIFF
--- a/docs/v1.0/out_elasticsearch.txt
+++ b/docs/v1.0/out_elasticsearch.txt
@@ -89,6 +89,14 @@ Here is a more practical example which partitions the Elasticsearch index by tag
     :::text
     index_name fluentd.${tag}.%Y%m%d
 
+Time placeholder needs to set up tag and time in chunk_keys.
+Also it needs to specify timekey for time slice of chunk:
+
+    :::text
+    <buffer tag, time>
+      timekey 1h # chunks per hours ("3600" also available)
+    </buffer>
+
 ### logstash_format (optional)
 
 With this option set `true`, Fluentd uses the conventional index name format `logstash-%Y.%m.%d` (default: `false`). This option supersedes the `index_name` option.


### PR DESCRIPTION
This issue is reported in https://github.com/uken/fluent-plugin-elasticsearch/issues/481.

Because time placeholder can work with a chunk which contains timekey
information.
Default buffer configuration does not contain timekey information but
tag information.

Default buffer configuration:

```aconf
<buffer tag>
  @type memory
</buffer>
```

When using the above default buffer configuration, elasticseatch plugin does not
extract time placeholder:

   index_name fluentd.${tag}.%Y%m%d
-> index_name fluentd.**your.tag**.%Y%m%d

tag and time in chunk_keys:

```aconf
<buffer tag, time>
  @type memory
  timekey 1h
</buffer>
```

When using buffer configuration with timekey, elasticsearch plugin can
handle time placeholder:

   index_name fluentd.${tag}.%Y%m%d
-> index_name fluentd.**your.tag.20181011**

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>