### PR TITLE
Fix links to the article "Writing Plugin Test Code"

### DIFF
--- a/docs/v1.0/api-plugin-filter.txt
+++ b/docs/v1.0/api-plugin-filter.txt
@@ -142,6 +142,6 @@ Lifecycle of plugins and test drivers is:
 4. Run test code (provided as a block for ``d.run``)
 5. Assert results of tests by data provided from driver
 
-Test drivers calls methods for plugin lifecycles at the beginning of 4. (``#start``) and the end of 4. (``#stop``, ``#shutdown``, ...). It can be skipped by optional arguments of ``#run``. See LINK:[Testing API for plugins](api-plugin-test) for details.
+Test drivers calls methods for plugin lifecycles at the beginning of 4. (``#start``) and the end of 4. (``#stop``, ``#shutdown``, ...). It can be skipped by optional arguments of ``#run``. See LINK:[Testing API for plugins](plugin-test-code) for details.
 
 For configuration tests, repeat 1-2. For full feature tests, repeat 1-5. Test drivers and helper methods will support it.

--- a/docs/v1.0/api-plugin-formatter.txt
+++ b/docs/v1.0/api-plugin-formatter.txt
@@ -150,7 +150,7 @@ Lifecycle of plugins and test drivers is:
 3. Run test code
 4. Assert results of tests by data provided from driver
 
-Test drivers instantiate the plugin. See LINK:[Testing API for plugins](api-plugin-test) for details.
+Test drivers instantiate the plugin. See LINK:[Testing API for plugins](plugin-test-code) for details.
 
 For configuration tests, repeat 1-2. For full feature tests, repeat 1-4. Test drivers and helper methods will support it.
 

--- a/docs/v1.0/api-plugin-input.txt
+++ b/docs/v1.0/api-plugin-input.txt
@@ -161,6 +161,6 @@ Lifecycle of plugins and test drivers is:
 4. Run test code (provided as a block for ``d.run``)
 5. Assert results of tests by data provided from driver
 
-Test drivers calls methods for plugin lifecycles at the beginning of 4. (``#start``) and the end of 4. (``#stop``, ``#shutdown``, ...). It can be skipped by optional arguments of ``#run``. See LINK:[Testing API for plugins](api-plugin-test) for details.
+Test drivers calls methods for plugin lifecycles at the beginning of 4. (``#start``) and the end of 4. (``#stop``, ``#shutdown``, ...). It can be skipped by optional arguments of ``#run``. See LINK:[Testing API for plugins](plugin-test-code) for details.
 
 For configuration tests, repeat 1-2. For full feature tests, repeat 1-5. Test drivers and helper methods will support it.

--- a/docs/v1.0/api-plugin-output.txt
+++ b/docs/v1.0/api-plugin-output.txt
@@ -459,7 +459,7 @@ Lifecycle of plugins and test drivers is:
  4. Run test code (provided as a block for ``d.run``)
  5. Assert results of tests by data provided from driver
 
-Test drivers calls methods for plugin lifecycles at the beginning of 4. (``#start``) and the end of 4. (``#stop``, ``#shutdown``, ...). It can be skipped by optional arguments of ``#run``. See LINK:[Testing API for plugins](api-plugin-test) for details.
+Test drivers calls methods for plugin lifecycles at the beginning of 4. (``#start``) and the end of 4. (``#stop``, ``#shutdown``, ...). It can be skipped by optional arguments of ``#run``. See LINK:[Testing API for plugins](plugin-test-code) for details.
 
 For configuration tests, repeat 1-2. For full feature tests, repeat 1-5. Test drivers and helper methods will support it.
 

--- a/docs/v1.0/api-plugin-parser.txt
+++ b/docs/v1.0/api-plugin-parser.txt
@@ -167,7 +167,7 @@ Lifecycle of plugins and test drivers is:
 3. Run test code
 4. Assert results of tests by data provided from driver
 
-Test drivers instantiate the plugin. See LINK:[Testing API for plugins](api-plugin-test) for details.
+Test drivers instantiate the plugin. See LINK:[Testing API for plugins](plugin-test-code) for details.
 
 For configuration tests, repeat 1-2. For full feature tests, repeat 1-4. Test drivers and helper methods will support it.
 

--- a/lib/toc.en.v0.14.rb
+++ b/lib/toc.en.v0.14.rb
@@ -356,7 +356,6 @@ section 'developer', 'Developer' do
     article 'api-plugin-buffer', 'Writing Buffer Plugins'
     article 'api-plugin-base', 'Plugin Base Class API'
     article 'api-config-types', 'Types of Configuration Parameters'
-    # article 'api-plugin-test', 'Testing API for plugins'
   end
   category 'plugin-helpers', 'Plugin Helper APIs' do
     article 'api-plugin-helper-child_process', 'ChildProcess Plugin Helper API'

--- a/lib/toc.en.v1.0.rb
+++ b/lib/toc.en.v1.0.rb
@@ -362,7 +362,6 @@ section 'developer', 'Developer' do
     article 'api-plugin-buffer', 'Writing Buffer Plugins'
     article 'api-plugin-base', 'Plugin Base Class API'
     article 'api-config-types', 'Types of Configuration Parameters'
-    # article 'api-plugin-test', 'Testing API for plugins'
   end
   category 'plugin-helpers', 'Plugin Helper APIs' do
     article 'api-plugin-helper-child_process', 'ChildProcess Plugin Helper API'


### PR DESCRIPTION
There are several links pointing to the (non-existent) article
"/api-plugin-test". This patch fixes up these dead links.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>