### PR TITLE
install-by-chef: Revive install-by-chef document for Fluentd v1

### DIFF
--- a/docs/v1.0/install-by-chef.txt
+++ b/docs/v1.0/install-by-chef.txt
@@ -1,0 +1,1 @@
+../v0.10/install-by-chef.txt

--- a/lib/toc.en.v1.0.rb
+++ b/lib/toc.en.v1.0.rb
@@ -11,7 +11,7 @@ section 'overview', 'Overview' do
     article 'install-by-dmg', 'Installing Fluentd using .dmg Package (MacOS X)'
     article 'install-by-msi', 'Installing Fluentd using .msi Package (Windows)'
     article 'install-by-gem', 'Installing Fluentd using Ruby Gem'
-    # article 'install-by-chef', 'Installing Fluentd using Chef'
+    article 'install-by-chef', 'Installing Fluentd using Chef'
     article 'install-from-source', 'Installing Fluentd from Source'
     # article 'install-on-heroku', 'Installing Fluentd on Heroku'
     # article 'install-on-beanstalk', 'Installing Fluentd on AWS Elastic Beanstalk'


### PR DESCRIPTION
This document is just stmbolic link for previous install-by-chef.txt.
Currently, it is enough for us.

Otherwise, the link for chef recipe is broken:
http://docs.fluentd.org/articles/install-by-chef

This is found in https://www.fluentd.org/faqs.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>