### PR TITLE
Remove extra space in config docs

### DIFF
--- a/docs/v0.10/config-file.txt
+++ b/docs/v0.10/config-file.txt
@@ -34,7 +34,7 @@ If you installed Fluentd using the Ruby Gem, you can create the configuration fi
 If you're using the Docker container, the default location is located at /fluentd/etc/fluent.conf
 To mount a config file from outside of Docker, use a bind-mount.
 
-    ::: term
+    :::term
     docker run -ti --rm -v /path/to/dir:/fluentd/etc fluentd -c /fluentd/etc/<conf-file> -v
 
 ## List of Directives

--- a/docs/v0.12/config-file.txt
+++ b/docs/v0.12/config-file.txt
@@ -34,7 +34,7 @@ If you installed Fluentd using the Ruby Gem, you can create the configuration fi
 If you're using the Docker container, the default location is located at /fluentd/etc/fluent.conf
 To mount a config file from outside of Docker, use a bind-mount.
 
-    ::: term
+    :::term
     docker run -ti --rm -v /path/to/dir:/fluentd/etc fluentd -c /fluentd/etc/<conf-file> -v
 
 #### FLUENT_CONF environment variable

--- a/docs/v1.0/config-file.txt
+++ b/docs/v1.0/config-file.txt
@@ -34,7 +34,7 @@ If you installed Fluentd using the Ruby Gem, you can create the configuration fi
 If you're using the Docker container, the default location is located at /fluentd/etc/fluent.conf
 To mount a config file from outside of Docker, use a bind-mount.
 
-    ::: term
+    :::term
     docker run -ti --rm -v /path/to/dir:/fluentd/etc fluentd -c /fluentd/etc/<conf-file> -v
 
 #### FLUENT_CONF environment variable


### PR DESCRIPTION
An extra space snuck in on the "term"s which made it actually show up on the help webpages.

<img width="609" alt="screen shot 2019-02-07 at 3 40 33 pm" src="https://user-images.githubusercontent.com/5041953/52441505-c8be2b80-2aee-11e9-9866-69efa51a390a.png">

Commit removes extra space in term.