### PR TITLE
Make the documentation v1.4.2 compatible

### DIFF
--- a/docs/v1.0/config-file.txt
+++ b/docs/v1.0/config-file.txt
@@ -304,11 +304,14 @@ The following match patterns can be used in `<match>` and `<filter>` tags.
 
   * This can be used in combination with the ``*`` or ``**`` patterns. Examples include ``a.{b,c}.*`` and ``a.{b,c.**}``
 
+* ``#{...}`` evaluates the string inside brackets as a Ruby expression (See the section "Embedding Ruby Expressions" below)
+
 * When multiple patterns are listed inside a single tag (delimited by one or more whitespaces), it matches any of the listed patterns. For example:
 
   * The patterns ``<match a b>`` match ``a`` and ``b``.
 
   * The patterns ``<match a.** b.*>`` match ``a``, ``a.b``, ``a.b.c`` (from the first pattern) and ``b.d`` (from the second pattern).
+
 
 ### Note on Match Order
 
@@ -352,6 +355,16 @@ The common pitfall is when you put a `<filter>` block after `<match>`. It will n
       @type file
       path /var/log/fluent/access
     </match>
+
+### Embedding Ruby Expressions
+
+Since Fluentd v1.4.0, you can use `#{...}` to embed arbitrary Ruby code into match patterns. Here is an example.
+
+    <match "app.#{ENV['FLUENTD_TAG']}">
+      @type stdout
+    </match>
+
+If you set the environment variable `FLUENTD_TAG` to `dev`, this evaluates to `app.dev`.
 
 ## Supported Data Types for Values
 

--- a/docs/v1.0/in_tcp.txt
+++ b/docs/v1.0/in_tcp.txt
@@ -96,6 +96,31 @@ then the client's hostname is set to `client_host` field.
         "client_host": "client.hostname.org"
     }
 
+### source_address_key
+
+| type   | default                        | version |
+|:------:|:------------------------------:|:-------:|
+| string | nil (no adding source address) | 1.4.2   |
+
+The field name for the client's IP address. If you set this option, Fluentd automatically adds the remote address to each data record.
+
+For example, if you have the following configuration:
+
+    <source>
+      @type tcp
+      source_address_key client_addr
+      ...
+    </source>
+
+you will get something like below:
+
+    :::text
+    {
+        ...
+        "client_addr": "192.168.10.10"
+        ...
+    }
+
 ### &lt;parse&gt; section
 
 | required | multi | version |

--- a/docs/v1.0/in_udp.txt
+++ b/docs/v1.0/in_udp.txt
@@ -84,6 +84,31 @@ then the client's hostname is set to `client_host` field.
         "client_host": "client.hostname.org"
     }
 
+### source_address_key
+
+| type   | default                        | version |
+|:------:|:------------------------------:|:-------:|
+| string | nil (no adding source address) | 1.4.2   |
+
+The field name for the client's IP address. If you set this option, Fluentd automatically adds the remote address to each data record.
+
+For example, if you have the following configuration:
+
+    <source>
+      @type udp
+      source_address_key client_addr
+      ...
+    </source>
+
+you will get something like below:
+
+    :::text
+    {
+        ...
+        "client_addr": "192.168.10.10"
+        ...
+    }
+
 ### message_length_limit
 
 | type | default | version |

--- a/docs/v1.0/out_file.txt
+++ b/docs/v1.0/out_file.txt
@@ -162,3 +162,39 @@ After flushed, you see actual output result
     /path/to/file.test.20180405.log_0 # tag is 'test'
 
 See also note in `path` parameter.
+
+### Can I use a placeholder in `symlink_path`?
+
+Since Fluentd v1.4.0, you can use the placeholder syntax in `symlink_path` parameter.
+For example, suppose you have the following configuration.
+
+    <source>
+      @type dummy
+      tag dummy1
+    </source>
+
+    <source>
+      @type dummy
+      tag dummy2
+    </source>
+
+    <match dummy*>
+      @type file
+      path /tmp/logs/${tag}
+      symlink_path /tmp/logs/current-${tag}
+      <buffer tag,time>
+        @type file
+      </buffer>
+    </match>
+
+This produces the following directory layout.
+
+    $ tree /tmp/logs/
+    /tmp/logs/
+    ├── ${tag}
+    │   ├── buffer.b57fb1dd96306dd0b308e094f7ec2228f.log
+    │   ├── buffer.b57fb1dd96306dd0b308e094f7ec2228f.log.meta
+    │   ├── buffer.b57fb1dd96339a870530991d4871cfe11.log
+    │   └── buffer.b57fb1dd96339a870530991d4871cfe11.log.meta
+    ├── current-dummy1 -> /tmp/logs/${tag}/buffer.b57fb1dd96339a870530991d4871cfe11.log
+    └── current-dummy2 -> /tmp/logs/${tag}/buffer.b57fb1dd96306dd0b308e094f7ec2228f.log


### PR DESCRIPTION
This is a series of patches that reflect recent new features to the documentation.

* Embed ruby expressions into match patterns via `#{...}`
* Embed placeholders into `symlink_path` in `out_file`
* New parameter `source_address_key` for in_udp
* New parameter `source_address_key` for in_tcp

With this, the documentation should catch up with the latest stable release.